### PR TITLE
fix: Add root-level event properties to SemanticEvent schema

### DIFF
--- a/schema/avro/README.md
+++ b/schema/avro/README.md
@@ -1,1 +1,149 @@
 # cxs-utils Schema in Avro format
+
+## SemanticEvent Schema
+
+The `SemanticEvent` schema is a central schema that aggregates various pieces of contextual information related to an event. It serves as a comprehensive data structure for capturing a wide range of event-related details.
+
+### Structure
+
+The `SemanticEvent` schema is defined in `semantic_event.avsc` and has the following key characteristics:
+
+- It includes core event properties like `event_gid`, `type`, `event`, `timestamp`, `message_id`, and `entity_gid` directly at the root level. These fields mirror the data in `BaseEventInfo` and are provided for convenience.
+- It also includes a `base_event_info` field, which contains the complete `BaseEventInfo` record, ensuring all original base event data is preserved and accessible.
+- It incorporates various other schemas as nested fields. These nested schemas represent specific aspects of the event context, such as `AccessInfo`, `App`, `Campaign`, `Commerce`, `Content`, `Context`, `Device`, `Entity`, `Media`, `Page`, `Product`, `Referrer`, `Screen`, `SemanticEventClassification`, `SemanticEventLocation`, `Sentiment`, `SourceInfo`, `UserAgent`, and more.
+- Most of these nested schemas are defined as arrays, allowing for multiple instances of each type (e.g., an event might have multiple classifications or involve multiple products).
+- These nested fields are optional and default to `null` if not applicable to a particular event.
+
+### Purpose
+
+The primary purpose of the `SemanticEvent` schema is to provide a unified and extensible way to represent complex events with rich contextual data. By combining various specialized schemas, it allows for flexibility in capturing diverse event types and their associated attributes.
+
+## Developer Guidance
+
+This section provides guidance for developers working with Avro schemas in the `cxs-utils` project.
+
+### Defining New Schemas
+
+-   **Namespace:** All schemas should belong to the `com.cxs.schema` namespace.
+-   **File Naming:** Schema files should be named descriptively using snake_case (e.g., `my_new_schema.avsc`).
+-   **Record Types:** Define data structures as `record` types.
+-   **Fields:**
+    -   Use clear and descriptive names for fields.
+    -   Provide a `doc` attribute for each field to explain its purpose.
+    -   Specify appropriate Avro data types. For optional fields, use a union with `null` (e.g., `["null", "string"]`) and provide a `default: null` value.
+    -   For fields that reference other schemas, use the fully qualified name of the schema (e.g., `com.cxs.schema.AnotherSchema`).
+
+### Compiling Schemas
+
+Apache Avro schemas (`.avsc` files) are often used directly by Avro libraries in various programming languages. These libraries can parse the schema definitions at runtime.
+
+However, for some use cases, particularly for static type checking or performance optimization, you might want to compile schemas into language-specific code (e.g., Java classes, Python classes).
+
+-   **Java:** Use the `avro-tools.jar` to compile schemas into Java classes.
+    ```bash
+    java -jar /path/to/avro-tools.jar compile schema <schema_file.avsc> <output_directory>
+    ```
+-   **Python:** Libraries like `fastavro` can compile schemas into Python modules for faster serialization/deserialization.
+    ```python
+    # Example using fastavro
+    from fastavro.schema import load_schema
+    from fastavro.codegen import CodeGenerator
+
+    schema = load_schema('path/to/your_schema.avsc')
+    codegen = CodeGenerator([schema])
+    codegen.write_code('output_module.py')
+    ```
+    Refer to the documentation of the specific Avro library you are using for detailed instructions on schema compilation.
+
+### Using Generated Code
+
+Once schemas are defined (and optionally compiled), you can use them in your application code to serialize and deserialize data.
+
+-   **Python Example (using `avro` library):**
+    ```python
+    import avro.schema
+    from avro.datafile import DataFileReader, DataFileWriter
+    from avro.io import DatumReader, DatumWriter
+
+    # Load schema
+    schema = avro.schema.parse(open("path/to/semantic_event.avsc", "rb").read())
+
+    # Writing Avro data
+    writer = DataFileWriter(open("events.avro", "wb"), DatumWriter(), schema)
+    # Example event (ensure it conforms to SemanticEvent schema)
+    event_data = {
+        "base_event_info": {
+            "event_gid": "some-uuid-goes-here",
+            "type": "example",
+            "event": "Example Event Created",
+            "timestamp": 1678886400000000, # Example timestamp in micros
+            "message_id": "msg-id-123",
+            "entity_gid": "entity-uuid-456"
+        },
+        # ... other fields like app, context, etc.
+        "app": [{
+            "name": "My Awesome App",
+            "version": "1.2.3",
+            "build": "100"
+            # ... other app fields
+        }]
+    }
+    writer.append(event_data)
+    writer.close()
+
+    # Reading Avro data
+    reader = DataFileReader(open("events.avro", "rb"), DatumReader())
+    for event in reader:
+        print(event)
+    reader.close()
+    ```
+
+-   **Java Example (using generated classes):**
+    ```java
+    // Assuming you have compiled SemanticEvent.avsc to com.cxs.schema.SemanticEvent
+    // and BaseEventInfo.avsc to com.cxs.schema.BaseEventInfo, etc.
+
+    // Creating an event
+    BaseEventInfo baseInfo = BaseEventInfo.newBuilder()
+        .setEventGid("some-uuid-goes-here")
+        .setType("example")
+        .setEvent("Example Event Created")
+        .setTimestamp(1678886400000000L) // Example timestamp in micros
+        .setMessageId("msg-id-123")
+        .setEntityGid("entity-uuid-456")
+        .build();
+
+    App appInfo = App.newBuilder()
+        .setName("My Awesome App")
+        .setVersion("1.2.3")
+        .setBuild("100")
+        .build();
+
+    SemanticEvent event = SemanticEvent.newBuilder()
+        .setBaseEventInfo(baseInfo)
+        .setApp(java.util.Arrays.asList(appInfo))
+        // ... set other fields
+        .build();
+
+    // Serializing (example using SpecificDatumWriter and DataFileWriter)
+    // try (DataFileWriter<SemanticEvent> dataFileWriter = new DataFileWriter<>(new SpecificDatumWriter<>(SemanticEvent.class))) {
+    // dataFileWriter.create(event.getSchema(), new File("events.avro"));
+    // dataFileWriter.append(event);
+    // } catch (IOException e) {
+    // e.printStackTrace();
+    // }
+
+    // Deserializing (example using SpecificDatumReader and DataFileReader)
+    // try (DataFileReader<SemanticEvent> dataFileReader = new DataFileReader<>(new File("events.avro"), new SpecificDatumReader<>(SemanticEvent.class))) {
+    // SemanticEvent readEvent = null;
+    // while (dataFileReader.hasNext()) {
+    // readEvent = dataFileReader.next(readEvent);
+    // System.out.println(readEvent);
+    // }
+    // } catch (IOException e) {
+    // e.printStackTrace();
+    // }
+    ```
+    (Note: The Java serialization/deserialization part is commented out as it would require setting up a full Java environment and Avro dependencies to be runnable code within this subtask. The focus here is on schema documentation.)
+
+Refer to the official Apache Avro documentation and the documentation for your chosen Avro library for more comprehensive examples and best practices.

--- a/schema/avro/semantic_event.avsc
+++ b/schema/avro/semantic_event.avsc
@@ -1,0 +1,188 @@
+{
+  "type": "record",
+  "name": "SemanticEvent",
+  "namespace": "com.cxs.schema",
+  "fields": [
+    {
+      "name": "event_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "The event gid of this semantic event, typically same as base_event_info.event_gid"
+    },
+    {
+      "name": "type",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The type of the semantic event (e.g. \"page\", \"track\"), mirrors base_event_info.type"
+    },
+    {
+      "name": "event",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The name of the semantic event (e.g. \"Page Viewed\"), mirrors base_event_info.event"
+    },
+    {
+      "name": "timestamp",
+      "type": {"type": "long", "logicalType": "timestamp-micros"},
+      "doc": "The timestamp of the semantic event in UTC, mirrors base_event_info.timestamp"
+    },
+    {
+      "name": "message_id",
+      "type": "string",
+      "doc": "The message ID of the semantic event, mirrors base_event_info.message_id"
+    },
+    {
+      "name": "entity_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "The entity GID of the semantic event, mirrors base_event_info.entity_gid"
+    },
+    {
+      "name": "base_event_info",
+      "type": "com.cxs.schema.BaseEventInfo"
+    },
+    {
+      "name": "access_info",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.AccessInfo"}],
+      "default": null
+    },
+    {
+      "name": "analysis",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Analysis"}],
+      "default": null
+    },
+    {
+      "name": "app",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.App"}],
+      "default": null
+    },
+    {
+      "name": "campaign",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Campaign"}],
+      "default": null
+    },
+    {
+      "name": "commerce",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Commerce"}],
+      "default": null
+    },
+    {
+      "name": "content",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Content"}],
+      "default": null
+    },
+    {
+      "name": "context",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Context"}],
+      "default": null
+    },
+    {
+      "name": "contextual_awareness",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.ContextualAwareness"}],
+      "default": null
+    },
+    {
+      "name": "device",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Device"}],
+      "default": null
+    },
+    {
+      "name": "embeddings",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Embeddings"}],
+      "default": null
+    },
+    {
+      "name": "entity",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Entity"}],
+      "default": null
+    },
+    {
+      "name": "id",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Id"}],
+      "default": null
+    },
+    {
+      "name": "involved",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Involved"}],
+      "default": null
+    },
+    {
+      "name": "library",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Library"}],
+      "default": null
+    },
+    {
+      "name": "media",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Media"}],
+      "default": null
+    },
+    {
+      "name": "network",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Network"}],
+      "default": null
+    },
+    {
+      "name": "os",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Os"}],
+      "default": null
+    },
+    {
+      "name": "page",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Page"}],
+      "default": null
+    },
+    {
+      "name": "product",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Product"}],
+      "default": null
+    },
+    {
+      "name": "referrer",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Referrer"}],
+      "default": null
+    },
+    {
+      "name": "screen",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Screen"}],
+      "default": null
+    },
+    {
+      "name": "semantic_event_classification",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.SemanticEventClassification"}],
+      "default": null
+    },
+    {
+      "name": "semantic_event_location",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.SemanticEventLocation"}],
+      "default": null
+    },
+    {
+      "name": "sentiment",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Sentiment"}],
+      "default": null
+    },
+    {
+      "name": "source_info",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.SourceInfo"}],
+      "default": null
+    },
+    {
+      "name": "traits",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Traits"}],
+      "default": null
+    },
+    {
+      "name": "uom",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.Uom"}],
+      "default": null
+    },
+    {
+      "name": "user_agent",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.UserAgent"}],
+      "default": null
+    },
+    {
+      "name": "user_agent_data",
+      "type": ["null", {"type": "array", "items": "com.cxs.schema.UserAgentData"}],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
This commit addresses feedback that core event properties were missing from the root of the SemanticEvent schema.

The following fields, mirroring those in BaseEventInfo, have been added directly to the SemanticEvent schema for easier access:
- event_gid
- type
- event
- timestamp
- message_id
- entity_gid

The `base_event_info` field is retained to ensure all original base event data remains accessible.

The documentation in `schema/avro/README.md` has been updated to reflect this change in the SemanticEvent schema structure and explain the reasoning.