### PR TITLE
Hi there! I've aligned the Avro schemas with ClickHouse, treating Cli…

### DIFF
--- a/schema/avro/access.avsc
+++ b/schema/avro/access.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "The type of the user. SQL Enum8('Blacklisted'=1, 'Whitelisted'=2)"
+      "type": "string",
+      "doc": "The type of the user"
     },
     {
       "name": "label",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The user ID of the user"
     },
     {

--- a/schema/avro/analysis.avsc
+++ b/schema/avro/analysis.avsc
@@ -19,6 +19,12 @@
       "doc": "The variant of the item that is involved in the event"
     },
     {
+      "name": "processing_time",
+      "type": ["null", "float"],
+      "default": null,
+      "doc": "The process time of the item that is involved in the event"
+    },
+    {
       "name": "token_in",
       "type": ["null", "int"],
       "default": null,
@@ -31,22 +37,15 @@
       "doc": "The token of the item that is involved in the event"
     },
     {
+      "name": "currency",
+      "type": "string",
+      "doc": "The currency of the item that is involved in the event"
+    },
+    {
       "name": "amount",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The price of the item that is involved in the event"
-    },
-    {
-      "name": "processing_time",
-      "type": ["null", "double"],
-      "default": null,
-      "doc": "The process time of the item that is involved in the event"
-    },
-    {
-      "name": "currency",
-      "type": ["null", "string"],
-      "default": "USD",
-      "doc": "The currency of the item that is involved in the event"
     }
   ]
 }

--- a/schema/avro/app.avsc
+++ b/schema/avro/app.avsc
@@ -5,26 +5,22 @@
   "fields": [
     {
       "name": "build",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The build of the app (e.g. \\\"1.1.0\\\")"
     },
     {
       "name": "name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the app (e.g. \\\"Segment\\\")"
     },
     {
       "name": "namespace",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The namespace of the app (e.g. \\\"com.segment.analytics\\\")"
     },
     {
       "name": "version",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The version of the app (e.g. \\\"1.1.0\\\")"
     }
   ]

--- a/schema/avro/base_event_info.avsc
+++ b/schema/avro/base_event_info.avsc
@@ -1,0 +1,38 @@
+{
+  "type": "record",
+  "name": "BaseEventInfo",
+  "namespace": "com.contextsuite.schema",
+  "doc": "Information about a base event, often used when an event is derived from one or more root events.",
+  "fields": [
+    {
+      "name": "event_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "The event gid of the root event"
+    },
+    {
+      "name": "type",
+      "type": "string",
+      "doc": "The type of the event (e.g. \\\"page\\\", \\\"track\\\", \\\"identify\\\", \\\"group\\\", \\\"alias\\\", \\\"screen\\\", \\\"commerce\\\")"
+    },
+    {
+      "name": "event",
+      "type": "string",
+      "doc": "The name of the event (e.g. \\\"Page Viewed\\\", \\\"Product Added\\\", \\\"User Signed Up\\\")"
+    },
+    {
+      "name": "timestamp",
+      "type": {"type": "long", "logicalType": "timestamp-micros"},
+      "doc": "The timestamp of the event in UTC (e.g. \\\"2022-01-01 00:00:00\\\")"
+    },
+    {
+      "name": "message_id",
+      "type": "string",
+      "doc": "The message ID of the base event"
+    },
+    {
+      "name": "entity_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "The entity GID of the event"
+    }
+  ]
+}

--- a/schema/avro/campaign.avsc
+++ b/schema/avro/campaign.avsc
@@ -5,32 +5,27 @@
   "fields": [
     {
       "name": "campaign",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The campaign (e.g. \\\"summer\\\")"
     },
     {
       "name": "source",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The source (e.g. \\\"google\\\")"
     },
     {
       "name": "medium",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The medium (e.g. \\\"cpc\\\")"
     },
     {
       "name": "term",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The term (e.g. \\\"beach\\\")"
     },
     {
       "name": "content",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The content (e.g. \\\"ad1\\\")"
     }
   ]

--- a/schema/avro/classification.avsc
+++ b/schema/avro/classification.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "The type of classification. SQL Enum8('Intent'=1, 'Intent Category'=2, 'Category'=3, 'Subcategory'=4, 'Tag'=5, 'Segmentation'=6, 'Age Group'=7, 'Inbox'=8, 'Keyword'=9, 'Priority'=10, 'Other'=0)"
+      "type": "string",
+      "doc": "The type of classification"
     },
     {
       "name": "value",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The category, tag, intent or whatever is being classified according to the type"
     },
     {
@@ -23,19 +21,19 @@
     },
     {
       "name": "score",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The score of the classification"
     },
     {
       "name": "confidence",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The confidence of the classification from the classification model"
     },
     {
       "name": "weight",
-      "type": "double",
+      "type": "float",
       "default": 0.0,
       "doc": "The relevance of the classification"
     }

--- a/schema/avro/commerce.avsc
+++ b/schema/avro/commerce.avsc
@@ -29,8 +29,7 @@
     },
     {
       "name": "employee_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Unique ID for the employee working the terminal/register"
     },
     {
@@ -41,50 +40,42 @@
     },
     {
       "name": "terminal_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Unique External ID for the terminal used for the transaction"
     },
     {
       "name": "affiliation_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Unique ID for the affiliation"
     },
     {
       "name": "affiliation",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Store or affiliation from which this transaction occurred (for example, Google Store)"
     },
     {
       "name": "agent",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The Agent responsible for the sale"
     },
     {
       "name": "agent_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the Agent responsible for the sale"
     },
     {
       "name": "sold_location",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The location where the sale occurred"
     },
     {
       "name": "sold_location_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the location where the sale occurred"
     },
     {
       "name": "business_day",
-      "type": ["null", {"type": "int", "logicalType": "date"}],
-      "default": null,
+      "type": {"type": "int", "logicalType": "date"},
       "doc": "The business day of the transaction"
     },
     {
@@ -119,8 +110,7 @@
     },
     {
       "name": "currency",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Currency code associated with the transaction"
     },
     {
@@ -131,20 +121,17 @@
     },
     {
       "name": "coupon",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Transaction coupon redeemed with the transaction"
     },
     {
       "name": "payment_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Type of payment (ex. Card, Paypal, Cash, etc.)"
     },
     {
       "name": "payment_sub_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Subtype of payment (ex. Visa, Mastercard, etc.)"
     },
     {
@@ -157,7 +144,7 @@
       "name": "products",
       "type": {"type": "array", "items": "com.contextsuite.schema.Product"},
       "default": [],
-      "doc": "Products involved in the commerce event"
+      "doc": "Individual products in the order, cart, product list, wishlist, etc."
     }
   ]
 }

--- a/schema/avro/content.avsc
+++ b/schema/avro/content.avsc
@@ -11,29 +11,26 @@
     {
       "name": "type",
       "type": "string",
-      "doc": "The type of content. SQL type hint: Enum8('Description'=1, 'Summary'=2, 'Conditions'=3, 'History'=4, 'Other'=0)"
+      "doc": "Enum8('Description'=1, 'Summary'=2, 'Conditions'=3, 'History'=4, 'Other'=0)"
     },
     {
       "name": "sub_type",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "The sub-type of content. SQL type hint: Enum8('short'=1, 'long'=2, 'other'=0)"
+      "type": "string",
+      "doc": "Enum8('short'=1, 'long'=2, 'other'=0)"
     },
     {
       "name": "value",
       "type": "string",
-      "doc": "The content value"
+      "doc": "The content of the event"
     },
     {
       "name": "language",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The primary language of the content (2 letter ISO code)"
     },
     {
       "name": "meta_description",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "A description of the contents' purpose and a few questions it may answer"
     }
   ]

--- a/schema/avro/context.avsc
+++ b/schema/avro/context.avsc
@@ -23,27 +23,23 @@
     },
     {
       "name": "locale",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The locale used where the event happened (e.g. \\\"en-US\\\")"
     },
     {
       "name": "group_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The group ID associated with the event (e.g. \\\"a89d88da-4f4b-11e5-9e98-2f3c942e34c8\\\")"
     },
     {
       "name": "timezone",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The timezone the event happened in (e.g. \\\"America/Los_Angeles\\\")"
     },
     {
       "name": "location",
-      "type": ["null", {"type": "array", "items": "double"}],
-      "default": null,
-      "doc": "The location associated with the event (e.g. [37.7576171,-122.5776844])"
+      "type": {"type": "array", "items": "double"},
+      "doc": "The location associated with the event (e.g. [longitude, latitude])"
     },
     {
       "name": "region",
@@ -71,8 +67,7 @@
     },
     {
       "name": "extras",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Other properties of the event that cannot be mapped to the schema or have complex data types"
     }
   ]

--- a/schema/avro/contextual_awareness.avsc
+++ b/schema/avro/contextual_awareness.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Description, Summary, Conditions, History, Other"
     },
     {
       "name": "entity_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The entity type that the event is associated with (e.g. \\\"Currency\\\", \\\"Product\\\", \\\"Service\\\", \\\"Other\\\")"
     },
     {

--- a/schema/avro/data_point.avsc
+++ b/schema/avro/data_point.avsc
@@ -1,0 +1,159 @@
+{
+  "type": "record",
+  "name": "DataPoint",
+  "namespace": "com.contextsuite.schema",
+  "fields": [
+    {
+      "name": "series_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "the gid of the metric that this datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "entity_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "GID for the entity that the datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "entity_gid_url",
+      "type": "string",
+      "doc": "GID URL for the entity that the datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "geohash",
+      "type": "string",
+      "doc": "Geolocation as a geohash (for clustering and sorting) - moves for non-stationary entities"
+    },
+    {
+      "name": "period",
+      "type": "string",
+      "doc": "The resolution/frequency of the data iso 8691 format (e.g., 'PT1H' for hourly, 'P1D' for daily, 'P1M' for monthly, etc.)"
+    },
+    {
+      "name": "timestamp",
+      "type": {"type": "long", "logicalType": "timestamp-micros"},
+      "doc": "The calendar date and time (Hourly interval) (UTC) at the start of the period for which the data is reported. This is the timestamp of the datapoint, not the time it was ingested."
+    },
+    {
+      "name": "owner_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "the gid of the owner that this datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "source_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "the gid of the source that this datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "publisher_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "the gid of the publisher that this datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "publication_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "the gid of the source that this datapoint belongs to. Links to an Entity"
+    },
+    {
+      "name": "gids",
+      "type": {"type": "map", "values": {"type": "string", "logicalType": "uuid"}},
+      "doc": "additional links to Named Entities"
+    },
+    {
+      "name": "location",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional geography for the datapoint"
+    },
+    {
+      "name": "demography",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional demography for the datapoint"
+    },
+    {
+      "name": "classification",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional classification for the datapoint"
+    },
+    {
+      "name": "topology",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional topology for the datapoint"
+    },
+    {
+      "name": "usage",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional usage for the datapoint"
+    },
+    {
+      "name": "device",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional device for the datapoint"
+    },
+    {
+      "name": "product",
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional product for the datapoint"
+    },
+    {
+      "name": "flags",
+      "type": {"type": "map", "values": "boolean"},
+      "doc": "additional flags for the datapoint"
+    },
+    {
+      "name": "tags",
+      "type": {"type": "array", "items": "string"},
+      "doc": "additional tags for the datapoint"
+    },
+    {
+      "name": "dimensions",
+      "type": {"type": "map", "values": "string"},
+      "doc": "dimensions for the entity - low cardinality string keys to allow for flexible dimensions and fit on a dashboard breaking down the datapoint"
+    },
+    {
+      "name": "metrics",
+      "type": {"type": "map", "values": "double"},
+      "doc": "metrics for the datapoint - the measurement"
+    },
+    {
+      "name": "mtype",
+      "type": {"type": "map", "values": "string"},
+      "doc": "the measurement type for a metrics"
+    },
+    {
+      "name": "uom",
+      "type": {"type": "map", "values": "string"},
+      "doc": "unit of measure for the metrics - All UOM are linked to a UOM Entity"
+    },
+    {
+      "name": "of_what",
+      "type": {"type": "map", "values": "string"},
+      "doc": "what is the metric measuring usually a standard based if from Wikidata/dbPedia etc. the key is the metric name and the value is the standard (e.g., 'population', 'oil', 'humidity', etc.)"
+    },
+    {
+      "name": "agg_method",
+      "type": {"type": "map", "values": "string"},
+      "doc": "the default aggregation method for the metric the key is the metric name and the value is the aggregation method (e.g., 'sum', 'avg', 'max', 'min', etc.)"
+    },
+    {
+      "name": "signature",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "The signature of the time_series + dimensions + of_what + metrics - used to ensure the right entries can be updated/replaced"
+    },
+    {
+      "name": "access_type",
+      "type": "string",
+      "doc": "Enum8('Local' = 0, 'Exclusive' = 1, 'Group' = 2, 'SharedPercentiles' = 3, 'SharedObfuscated' = 4, 'Shared' = 5, 'Public' = 6) DEFAULT(1)",
+      "default": "Exclusive"
+    },
+    {
+      "name": "partition",
+      "type": "string",
+      "doc": "The version of the event message"
+    },
+    {
+      "name": "sign",
+      "type": "int",
+      "doc": "Used by ReplacingMergeTree to determine if a row is active or deleted. Default 1 means active.",
+      "default": 1
+    }
+  ]
+}

--- a/schema/avro/device.avsc
+++ b/schema/avro/device.avsc
@@ -11,80 +11,67 @@
     },
     {
       "name": "id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The manufacturer id for the device (e.g. \\\"e3bcf3f796b9f377284bfbfbcf1f8f92b6\\\")"
     },
     {
       "name": "version",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The device version (e.g. \\\"9.1\\\")"
     },
     {
       "name": "mac_address",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The device mac address (e.g. \\\"00:00:00:00:00:00\\\")"
     },
     {
       "name": "manufacturer",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The manufacturer of the device (e.g. \\\"Apple\\\")"
     },
     {
       "name": "model",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The model of the device (e.g. \\\"iPhone 6\\\")"
     },
     {
       "name": "name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the device (e.g. \\\"Nexus 5\\\")"
     },
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the device (e.g. \\\"Mobile\\\", \\\"Tablet\\\", \\\"Desktop\\\", \\\"TV\\\", \\\"Wearable\\\", \\\"Other\\\")"
     },
     {
       "name": "token",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The token of the device (e.g. \\\"e3bcf3f796b9f377284bfbfbcf1f8f92b6\\\")"
     },
     {
       "name": "locale",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The locale of the device (e.g. \\\"en-US\\\")"
     },
     {
       "name": "timezone",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The timezone of the device (e.g. \\\"America/Los_Angeles\\\")"
     },
     {
       "name": "brand",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The manufacturer of the device (e.g. \\\"Apple\\\")"
     },
     {
       "name": "variant",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The variant of the device (e.g. \\\"iPhone 6s\\\")"
     },
     {
       "name": "advertising_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The advertising ID of the device (e.g. \\\"350e9d90-d7f5-11e4-b9d6-1681e6b88ec1\\\")"
     }
   ]

--- a/schema/avro/embeddings.avsc
+++ b/schema/avro/embeddings.avsc
@@ -9,39 +9,34 @@
       "doc": "The label of the embedding matches the content label (e.g. \\\"Prologue\\\", \\\"Synopsis\\\", \\\"Description\\\", \\\"Summary\\\", \\\"Conditions\\\", \\\"History\\\", \\\"Other\\\")"
     },
     {
-      "name": "model",
-      "type": "string",
-      "doc": "The model used to generate the embedding (e.g. \\\"text-embedding-3-small\\\", \\\"text-embedding-3-large\\\")"
-    },
-    {
-      "name": "vectors",
-      "type": ["null", {"type": "array", "items": "double"}],
-      "default": null,
-      "doc": "The vectors of the embedding, used for similarity search and clustering, usually 1024 dimensions"
-    },
-    {
       "name": "content_starts",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The content that starts the embedding (e.g. \\\"Title: \\\", \\\"Description: \\\", \\\"Content: \\\")"
     },
     {
       "name": "content_ends",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The content that ends the embedding (e.g. \\\" \\\", \\\".\\\", \\\" - \\\")"
     },
     {
       "name": "opening_phrase",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The opening phrase of the embedding (e.g. \\\"This is a description of \\\", \\\"This is a content of \\\")"
     },
     {
       "name": "closing_phrase",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The closing phrase of the embedding (e.g. \\\" for more information.\\\", \\\" for more details.\\\")"
+    },
+    {
+      "name": "vectors",
+      "type": {"type": "array", "items": "double"},
+      "doc": "The vectors of the embedding, used for similarity search and clustering, usually 1024 dimensions"
+    },
+    {
+      "name": "model",
+      "type": "string",
+      "doc": "The model used to generate the embedding (e.g. \\\"text-embedding-3-small\\\", \\\"text-embedding-3-large\\\")"
     }
   ]
 }

--- a/schema/avro/entity.avsc
+++ b/schema/avro/entity.avsc
@@ -20,69 +20,58 @@
     },
     {
       "name": "labels",
-      "type": ["null", {"type": "array", "items": "string"}],
-      "default": null,
+      "type": {"type": "array", "items": "string"},
       "doc": "Additional labels for the entity with language prefixes (e.g. [\\\"en:Eiffel Tower\\\", \\\"fr:Tour Eiffel\\\"])"
     },
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the entity (e.g. \\\"Event\\\", \\\"Place\\\", \\\"Person\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "variant",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The variant of the entity (e.g. \\\"Concert\\\", \\\"Exhibition\\\", \\\"Match\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "icon",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The icon of the entity (e.g. \\\"concert\\\", \\\"exhibition\\\", \\\"match\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "colour",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The colour of the entity (e.g. \\\"red\\\", \\\"blue\\\", \\\"green\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "dimensions",
-      "type": ["null", {"type": "map", "values": "string"}],
-      "default": null,
+      "type": {"type": "map", "values": "string"},
       "doc": "additional (generic) dimensions for the entity"
     },
     {
       "name": "tags",
-      "type": ["null", {"type": "array", "items": "string"}],
-      "default": null,
+      "type": {"type": "array", "items": "string"},
       "doc": "additional tags for the entity"
     },
     {
       "name": "flags",
-      "type": ["null", {"type": "map", "values": "boolean"}],
-      "default": null,
+      "type": {"type": "map", "values": "boolean"},
       "doc": "additional flags for the entity"
     },
     {
       "name": "metrics",
-      "type": ["null", {"type": "map", "values": "double"}],
-      "default": null,
+      "type": {"type": "map", "values": "double"},
       "doc": "additional metrics for the entity"
     },
     {
       "name": "properties",
-      "type": ["null", {"type": "map", "values": "string"}],
-      "default": null,
+      "type": {"type": "map", "values": "string"},
       "doc": "additional properties for the entity"
     },
     {
       "name": "names",
-      "type": ["null", {"type": "map", "values": "string"}],
-      "default": null,
-      "doc": "additional names for the entity, e.g. \\\"en:Eiffel Tower\\\" -> \\\"fr:Tour Eiffel\\\""
+      "type": {"type": "map", "values": "string"},
+      "doc": "additional names for the entity, e.g. \\\"Eiffel Tower\\\" -> \\\"Tour Eiffel\\\""
     },
     {
       "name": "ids",
@@ -123,8 +112,7 @@
     {
       "name": "partition",
       "type": "string",
-      "doc": "The storage partition for the entity. This is internal and can not be submitted by the user. It is used to partition the data for performance and scalability.",
-      "default": "_open_"
+      "doc": "The storage partition for the entity. This is internal and can not be submitted by the user. It is used to partition the data for performance and scalability."
     },
     {
       "name": "sign",

--- a/schema/avro/entity_classification.avsc
+++ b/schema/avro/entity_classification.avsc
@@ -5,25 +5,22 @@
   "fields": [
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The event category-> subcategory"
     },
     {
       "name": "value",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "like Sports->Football, Concert->Pop etc."
     },
     {
       "name": "babelnet_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The concept ID for the classification (Used to translate and associate the classification with other systems)"
     },
     {
       "name": "weight",
-      "type": "double",
+      "type": "float",
       "default": 0.0,
       "doc": "The relevance of the classification"
     }

--- a/schema/avro/entity_linking.avsc
+++ b/schema/avro/entity_linking.avsc
@@ -5,8 +5,7 @@
   "fields": [
     {
       "name": "content_key",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of content (e.g. \\\"body\\\", \\\"subject\\\", \\\"title\\\", \\\"description\\\", \\\"summary\\\", \\\"quick response\\\", \\\"other\\\")"
     },
     {
@@ -47,7 +46,7 @@
     },
     {
       "name": "certainty",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The certainty of the entity linking"
     }

--- a/schema/avro/entity_location.avsc
+++ b/schema/avro/entity_location.avsc
@@ -15,62 +15,52 @@
     },
     {
       "name": "country",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The country of the location (e.g. \\\"France\\\", \\\"United States\\\", \\\"Germany\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "country_code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The 3 letter country code of the location (e.g. \\\"FRA\\\", \\\"USA\\\", \\\"DEU\\\"), always in uppercase"
     },
     {
       "name": "code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The code of the location (e.g. \\\"75001\\\", \\\"10001\\\", \\\"10115\\\"), always in uppercase"
     },
     {
       "name": "region",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The region of the location (e.g. \\\"Île-de-France\\\", \\\"New York\\\", \\\"Berlin\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "division",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The division of the location (e.g. \\\"Paris\\\", \\\"Manhattan\\\", \\\"Mitte\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "municipality",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The municipality of the location (e.g. \\\"Paris\\\", \\\"New York\\\", \\\"Berlin\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "locality",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The locality/neighbourhood of the location (e.g. \\\"Montmartre\\\", \\\"SoHo\\\", \\\"Kreuzberg\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "postal_code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The postal code of the location (e.g. \\\"75001\\\", \\\"10001\\\", \\\"10115\\\"), always in uppercase"
     },
     {
       "name": "postal_name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the postal code area (e.g. \\\"1er Arrondissement\\\", \\\"Chelsea\\\", \\\"Mitte\\\"), always in English and in singular form and capitalized"
     },
     {
       "name": "street",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The street of the location (e.g. \\\"Rue de Rivoli\\\", \\\"Broadway\\\", \\\"Friedrichstraße\\\"), always in English and in singular form and capitalized"
     },
     {

--- a/schema/avro/id.avsc
+++ b/schema/avro/id.avsc
@@ -11,14 +11,12 @@
     },
     {
       "name": "role",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The role of the entity in the event"
     },
     {
       "name": "entity_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the entity that is involved in the event"
     },
     {
@@ -35,13 +33,12 @@
     },
     {
       "name": "id_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the entity that is involved in the event"
     },
     {
       "name": "capacity",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The capacity of the entity in the event"
     }

--- a/schema/avro/involved.avsc
+++ b/schema/avro/involved.avsc
@@ -11,14 +11,12 @@
     },
     {
       "name": "role",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The role of the entity in the event. (Capitalized like: Supplier, Buyer, Victim, HomeTeam)"
     },
     {
       "name": "entity_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the entity that is involved in the event (Capitalized Entity name like: Person, Organization, LegalEntity)"
     },
     {
@@ -35,13 +33,12 @@
     },
     {
       "name": "id_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID type indicates what organization issued the ID. (This is potentially your own name)"
     },
     {
       "name": "capacity",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The capacity of the entity in the event. If the involvement is fractional, this is the fraction of the entity that is involved in the event. (e.g. 0.5 for half of a person)"
     }

--- a/schema/avro/library.avsc
+++ b/schema/avro/library.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the library (e.g. \\\"analytics-ios\\\")"
     },
     {
       "name": "version",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The version of the library (e.g. \\\"3.0.0\\\")"
     }
   ]

--- a/schema/avro/location.avsc
+++ b/schema/avro/location.avsc
@@ -5,74 +5,62 @@
   "fields": [
     {
       "name": "location_of",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of location (e.g. \\\"Customer\\\", \\\"Supplier\\\", \\\"Postal Address\\\", \\\"Business Address\\\", \\\"Home Address\\\", \\\"Other\\\")"
     },
     {
       "name": "label",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The label of the location (e.g. \\\"Street name 1, 1234\\\")"
     },
     {
       "name": "country",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the country (e.g.\\\"Iceland\\\")"
     },
     {
       "name": "country_code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The country code (e.g. \\\"IS\\\")"
     },
     {
       "name": "code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The code of the location (e.g. \\\"1234\\\")"
     },
     {
       "name": "region",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The region of the location (e.g. \\\"Gullbringu og kjósarsýsla\\\")"
     },
     {
       "name": "division",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The division of the location (e.g. \\\"Capital Region\\\")"
     },
     {
       "name": "municipality",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The municipality of the location (e.g. \\\"Reykjavik\\\")"
     },
     {
       "name": "locality",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The locality of the location (e.g. \\\"Vesturbær\\\")"
     },
     {
       "name": "postal_code",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The postal code of the location (e.g. \\\"101\\\")"
     },
     {
       "name": "postal_name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the postal code (e.g. \\\"Vesturbær\\\")"
     },
     {
       "name": "street",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The street of the location (e.g. \\\"Laugavegur\\\")"
     },
     {

--- a/schema/avro/media.avsc
+++ b/schema/avro/media.avsc
@@ -10,14 +10,12 @@
     },
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Poster, Thumbnail, etc."
     },
     {
       "name": "sub_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Program, Season, Episode, etc."
     },
     {
@@ -27,14 +25,12 @@
     },
     {
       "name": "language",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The primary language of the media"
     },
     {
       "name": "aspect_ratio",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The aspect ratio of the media"
     }
   ]

--- a/schema/avro/network.avsc
+++ b/schema/avro/network.avsc
@@ -4,6 +4,11 @@
   "namespace": "com.contextsuite.schema",
   "fields": [
     {
+      "name": "carrier",
+      "type": "string",
+      "doc": "The network carrier of the library (e.g. \\\"Verizon\\\")"
+    },
+    {
       "name": "cellular",
       "type": ["null", "boolean"],
       "default": null,
@@ -20,12 +25,6 @@
       "type": ["null", "boolean"],
       "default": null,
       "doc": "Whether the network is wifi (e.g. \\\"true\\\")"
-    },
-    {
-      "name": "carrier",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "The network carrier of the device (e.g. \\\"Verizon\\\")"
     }
   ]
 }

--- a/schema/avro/os.avsc
+++ b/schema/avro/os.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The OS of the device (e.g. \\\"iOS\\\")"
     },
     {
       "name": "version",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The OS version of the device (e.g. \\\"9.1\\\")"
     }
   ]

--- a/schema/avro/page.avsc
+++ b/schema/avro/page.avsc
@@ -5,50 +5,42 @@
   "fields": [
     {
       "name": "encoding",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The encoding of the page (e.g. \\\"UTF-8\\\")"
     },
     {
       "name": "host",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The host of the page (e.g. \\\"segment.com\\\")"
     },
     {
       "name": "path",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The path of the page (e.g. \\\"/docs\\\")"
     },
     {
       "name": "referrer",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The referrer of the page (e.g. \\\"https://segment.com\\\")"
     },
     {
       "name": "referring_domain",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The referring domain of the page (e.g. \\\"segment.com\\\")"
     },
     {
       "name": "search",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The search of the page (e.g. \\\"segment\\\")"
     },
     {
       "name": "title",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The title of the page (e.g. \\\"Analytics.js Quickstart - Segment\\\")"
     },
     {
       "name": "url",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The url of the page (e.g. \\\"https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/\\\")"
     }
   ]

--- a/schema/avro/product.avsc
+++ b/schema/avro/product.avsc
@@ -11,9 +11,8 @@
     },
     {
       "name": "entry_type",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "'Cart Item', 'Line Item', 'Wishlist', 'Recommendation', 'Purchase Order', 'Search Results', 'Other', 'Delivery', 'Reservation', 'Stockout'"
+      "type": "string",
+      "doc": "'Cart Item', 'Line Item', 'Wishlist', 'Recommendation', 'Purchase Order', 'Search Results', 'Other', 'Delivery', 'Reservation', 'Reservation', 'Stockout'"
     },
     {
       "name": "line_id",
@@ -23,116 +22,97 @@
     },
     {
       "name": "product_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Database id of the product being purchases"
     },
     {
       "name": "entity_gid",
-      "type": ["null", {"type": "string", "logicalType": "uuid"}],
-      "default": null,
+      "type": {"type": "string", "logicalType": "uuid"},
       "doc": "Database id of the product being purchases"
     },
     {
       "name": "sku",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Sku of the product being purchased"
     },
     {
       "name": "barcode",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Barcode of the product being purchased"
     },
     {
       "name": "gtin",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GTIN of the product being purchased"
     },
     {
       "name": "upc",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "UPC of the product being purchased"
     },
     {
       "name": "ean",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "EAN of the product being purchased"
     },
     {
       "name": "isbn",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "ISBN of the product being purchased"
     },
     {
       "name": "serial_number",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Serial number of the product being purchased"
     },
     {
       "name": "supplier_number",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Supplier number of the product being purchased"
     },
     {
       "name": "tpx_serial_number",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Serial number of the product being purchased issued by a third party (not GS1)"
     },
     {
       "name": "bundle_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the bundle the product belongs to when listing all products in a bundle"
     },
     {
       "name": "bundle",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the bundle the product belongs to"
     },
     {
       "name": "product",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Name of the product being viewed"
     },
     {
       "name": "variant",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Variant of the product being purchased"
     },
     {
       "name": "novelty",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Novelty of the product being purchased"
     },
     {
       "name": "size",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Size of the product being purchased"
     },
     {
       "name": "packaging",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Packaging of the product being purchased"
     },
     {
       "name": "condition",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Condition of the product being purchased //like fresh, frozen, etc."
     },
     {
@@ -143,26 +123,22 @@
     },
     {
       "name": "core_product",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The core product being purchased // Spaghetti, Razor Blades (No Brand, No Variant, No Category)"
     },
     {
       "name": "origin",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Location identifier for the origin of the product being purchased"
     },
     {
       "name": "brand",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Brand associated with the product"
     },
     {
       "name": "product_line",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product line associated with the product"
     },
     {
@@ -173,98 +149,77 @@
     },
     {
       "name": "product_dist",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product Distribution is used to track the distribution class of the product (e.g. \\\"A\\\", \\\"B\\\", \\\"C\\\", \\\"D\\\", \\\"E\\\", \\\"F\\\", \\\"G\\\", \\\"H\\\", \\\"I\\\", \\\"J\\\")"
     },
     {
       "name": "main_category",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product category being purchased"
     },
     {
       "name": "main_category_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product category ID being purchased"
     },
     {
       "name": "category",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Name of the sub-category of the product being purchased"
     },
     {
       "name": "category_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "ID of the sub-category of the product being purchased"
     },
     {
-      "name": "income_category",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "Income category of the product being purchased"
-    },
-    {
       "name": "gs1_brick_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick ID of the product being purchased"
     },
     {
       "name": "gs1_brick",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Name of the product being purchased"
     },
     {
       "name": "gs1_brick_short",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Short Name"
     },
     {
       "name": "gs1_brick_variant",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Variant"
     },
     {
       "name": "gs1_conditions",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Conditions"
     },
     {
       "name": "gs1_processed",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Processed"
     },
     {
       "name": "gs1_consumable",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Brick Processed"
     },
     {
       "name": "gs1_class",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Class"
     },
     {
       "name": "gs1_family",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Family"
     },
     {
       "name": "gs1_segment",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "GS1 Segment"
     },
     {
@@ -281,7 +236,7 @@
     },
     {
       "name": "duration",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "Duration for the product being purchased in minutes"
     },
@@ -299,7 +254,7 @@
     },
     {
       "name": "lead_time",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "Lead time in days from the product being purchased until it's delivered (from purchase data to delivery date)"
     },
@@ -311,50 +266,42 @@
     },
     {
       "name": "supplier",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Supplier of the product being purchased"
     },
     {
       "name": "supplier_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Supplier ID of the product being purchased"
     },
     {
       "name": "manufacturer",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Manufacturer of the product being purchased"
     },
     {
       "name": "manufacturer_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Manufacturer ID of the product being purchased"
     },
     {
       "name": "promoter",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Promoter of the product being purchased"
     },
     {
       "name": "promoter_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Promoter ID of the product being purchased"
     },
     {
       "name": "product_mgr_id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product Manager ID of the product being purchased"
     },
     {
       "name": "product_mgr",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Product Manager of the product being purchased"
     },
     {
@@ -371,8 +318,7 @@
     },
     {
       "name": "uom",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Unit of measure of the product(s) being purchased (Weight, Duration, Items, Volume, etc.)"
     },
     {
@@ -395,38 +341,41 @@
     },
     {
       "name": "price_bracket",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Price bracket of the product being purchased"
     },
     {
+      "name": "income_category",
+      "type": "string",
+      "doc": "Income category of the product being purchased"
+    },
+    {
       "name": "tax_percentage",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "Total tax-percentage associated with the product purchase (unit_price * units * tax_rate = tax)"
     },
     {
       "name": "discount_percentage",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The discount-percentage applied to the product (unit_price * units * discount_rate = discount)"
     },
     {
       "name": "kickback_percentage",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The discount-percentage applied to the product (unit_price * units * discount_rate = discount)"
     },
     {
       "name": "commission",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The total commission percentage applied to the product on the line basis (unit_price * units * commission_rate = commission)"
     },
     {
       "name": "coupon",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "Coupon code associated with a product (for example, MAY_DEALS_3)"
     },
     {

--- a/schema/avro/referrer.avsc
+++ b/schema/avro/referrer.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The referrer ID of the library (e.g. \\\"3c8da4a4-4f4b-11e5-9e98-2f3c942e34c8\\\")"
     },
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The referrer type of the library (e.g. \\\"dataxu\\\")"
     }
   ]

--- a/schema/avro/semantic_event.avsc
+++ b/schema/avro/semantic_event.avsc
@@ -4,181 +4,327 @@
   "namespace": "com.contextsuite.schema",
   "fields": [
     {
-      "name": "event_gid",
+      "name": "entity_gid",
       "type": {"type": "string", "logicalType": "uuid"},
-      "doc": "The event gid of this semantic event, typically same as base_event_info.event_gid"
+      "doc": "The entity that the event is associated with (Context Suite Specific) (Account or any sub-entity)"
+    },
+    {
+      "name": "timestamp",
+      "type": {"type": "long", "logicalType": "timestamp-micros"},
+      "doc": "The timestamp of the event is always stored in UTC"
     },
     {
       "name": "type",
       "type": ["null", "string"],
       "default": null,
-      "doc": "The type of the semantic event (e.g. \"page\", \"track\", \"identify\", \"group\", \"alias\", \"screen\", \"commerce\")"
+      "doc": "The event type (e.g. \"track, page, identify, group, alias, screen etc.\")"
     },
     {
       "name": "event",
       "type": ["null", "string"],
       "default": null,
-      "doc": "The name of the semantic event (e.g. \"Page Viewed\"), mirrors base_event_info.event"
+      "doc": "The event name (e.g. \"Product Added\") always capitalized and always ended with a verb in passed tense"
     },
     {
-      "name": "timestamp",
-      "type": {"type": "long", "logicalType": "timestamp-micros"},
-      "doc": "The timestamp of the semantic event in UTC, mirrors base_event_info.timestamp"
+      "name": "anonymous_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The anonymous ID of the user before they are identified"
+    },
+    {
+      "name": "anonymous_gid",
+      "type": ["null", {"type": "string", "logicalType": "uuid"}],
+      "default": null,
+      "doc": "The anonymous ID of the user before they are identified"
+    },
+    {
+      "name": "user_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The user ID of the user"
+    },
+    {
+      "name": "user_gid",
+      "type": ["null", {"type": "string", "logicalType": "uuid"}],
+      "default": null,
+      "doc": "The user ID of the user"
+    },
+    {
+      "name": "account_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The account ID of the user (Often the same as the entity_gid)"
+    },
+    {
+      "name": "previous_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The user ID of the user before the event (e.g. \"anonymousId\" before \"identify\")"
+    },
+    {
+      "name": "session_id",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The session ID of the user in the client that generated the event"
+    },
+    {
+      "name": "session_gid",
+      "type": ["null", {"type": "string", "logicalType": "uuid"}],
+      "default": null,
+      "doc": "The session GID of the user session that generated the event"
+    },
+    {
+      "name": "context_ip",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The IP of the user in IPv4 format"
+    },
+    {
+      "name": "importance",
+      "type": ["null", "int"],
+      "default": null,
+      "doc": "The importance of the event (eg. 1..5)"
+    },
+    {
+      "name": "customer_facing",
+      "type": "int",
+      "default": 0,
+      "doc": "The session ID of the user in the client that generated the event"
+    },
+    {
+      "name": "content",
+      "type": ["null", {"type": "map", "values": "string"}],
+      "default": null,
+      "doc": "The type of content (e.g. \"Body\", \"Subject\", \"Title\", \"Description\", \"Summary\", \"Initial Response\", \"Other\")"
+    },
+    {
+      "name": "involves",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Involved"}],
+      "default": null,
+      "doc": "Involvement can be implicit (via other properties) or explicit using this structure"
+    },
+    {
+      "name": "sentiment",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Sentiment"}],
+      "default": null,
+      "doc": "Sentiment is a Context Suite Specific array if sentiment objects used to track entity sentiment expressed in the event"
+    },
+    {
+      "name": "classification",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Classification"}],
+      "default": null,
+      "doc": "Classification is a Context Suite Specific property used to track the classification of the event //Intent, Categories, Subcategories, Tags, Confidence, Score, Segmentation, etc."
+    },
+    {
+      "name": "location",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Location"}],
+      "default": null,
+      "doc": "Location is a Context Suite Specific property used to track the location of the event"
+    },
+    {
+      "name": "entity_linking",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.EntityLinking"}],
+      "default": null,
+      "doc": "An array of entity links. ntity Linking is used to link an entity mention to a specific named entity in the graph"
+    },
+    {
+      "name": "contextual_awareness",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.ContextualAwareness"}],
+      "default": null,
+      "doc": "Contextual Awareness is a Context Suite Specific property used to track additional context for entities involved in the event"
+    },
+    {
+      "name": "properties",
+      "type": ["null", {"type": "map", "values": "string"}],
+      "default": null,
+      "doc": "A dictionary of additional properties for the event in any JSON format. -- Properties are all moved into dedicated columns, if possible. If not, they are stored in properties"
+    },
+    {
+      "name": "dimensions",
+      "type": ["null", {"type": "map", "values": "string"}],
+      "default": null,
+      "doc": "Additional dimensions for the event, There are low-cardinality dimensions that are not defined in the schema and used on dashboards"
+    },
+    {
+      "name": "metrics",
+      "type": ["null", {"type": "map", "values": "float"}],
+      "default": null,
+      "doc": "Additional metrics for the event. These are additional metrics that are not defined in the schema and used on dashboards"
+    },
+    {
+      "name": "flags",
+      "type": ["null", {"type": "map", "values": "boolean"}],
+      "default": null,
+      "doc": "Boolean flags for the event. These are additional flags that are not defined in the schema and used on dashboards"
+    },
+    {
+      "name": "campaign",
+      "type": ["null", "com.contextsuite.schema.Campaign"],
+      "default": null,
+      "doc": "Standard marketing campaign properties"
+    },
+    {
+      "name": "app",
+      "type": ["null", "com.contextsuite.schema.App"],
+      "default": null,
+      "doc": "Mobile application properties"
+    },
+    {
+      "name": "device",
+      "type": ["null", "com.contextsuite.schema.Device"],
+      "default": null,
+      "doc": "Device properties"
+    },
+    {
+      "name": "os",
+      "type": ["null", "com.contextsuite.schema.OperatingSystem"],
+      "default": null,
+      "doc": "Operating system properties"
+    },
+    {
+      "name": "library",
+      "type": ["null", "com.contextsuite.schema.Library"],
+      "default": null,
+      "doc": "Event library properties"
+    },
+    {
+      "name": "user_agent",
+      "type": ["null", "com.contextsuite.schema.UserAgent"],
+      "default": null,
+      "doc": "User agent properties"
+    },
+    {
+      "name": "network",
+      "type": ["null", "com.contextsuite.schema.Network"],
+      "default": null,
+      "doc": "Network properties"
+    },
+    {
+      "name": "traits",
+      "type": ["null", "com.contextsuite.schema.Traits"],
+      "default": null,
+      "doc": "User traits (should be used with caution and awareness of PII)"
+    },
+    {
+      "name": "page",
+      "type": ["null", "com.contextsuite.schema.Page"],
+      "default": null,
+      "doc": "Page properties"
+    },
+    {
+      "name": "referrer",
+      "type": ["null", "com.contextsuite.schema.Referrer"],
+      "default": null,
+      "doc": "Referrer properties"
+    },
+    {
+      "name": "screen",
+      "type": ["null", "com.contextsuite.schema.Screen"],
+      "default": null,
+      "doc": "Screen properties"
+    },
+    {
+      "name": "context",
+      "type": ["null", "com.contextsuite.schema.Context"],
+      "default": null,
+      "doc": "Event context properties"
+    },
+    {
+      "name": "commerce",
+      "type": ["null", "com.contextsuite.schema.Commerce"],
+      "default": null,
+      "doc": "Commerce and product related properties"
+    },
+    {
+      "name": "analysis",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Analysis"}],
+      "default": null,
+      "doc": "Analysis array is used to track the cost associated with analysis of the event. This is strictly for internal use and should not be used for any other purpose"
+    },
+    {
+      "name": "base_events",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.BaseEventInfo"}],
+      "default": null,
+      "doc": "If this is a derived event (higher order) then this will be populated with the base event information"
+    },
+    {
+      "name": "access",
+      "type": ["null", {"type": "array", "items": "com.contextsuite.schema.Access"}],
+      "default": null,
+      "doc": "Black or whitelist of users that have access to the event or not"
+    },
+    {
+      "name": "source",
+      "type": ["null", "com.contextsuite.schema.SourceInfo"],
+      "default": null,
+      "doc": "Source and access information for the event origin"
+    },
+    {
+      "name": "local_time",
+      "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+      "default": null,
+      "doc": "The original timestamp of the event"
+    },
+    {
+      "name": "original_timestamp",
+      "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+      "default": null,
+      "doc": "The original timestamp of the event"
+    },
+    {
+      "name": "received_at",
+      "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+      "default": null,
+      "doc": "The time the event was received by Segment"
+    },
+    {
+      "name": "sent_at",
+      "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+      "default": null,
+      "doc": "The timestamp of when the event was sent"
     },
     {
       "name": "message_id",
       "type": "string",
-      "doc": "The message ID of the semantic event, mirrors base_event_info.message_id"
+      "doc": "A unique ID for each message as assigned by the client library"
     },
     {
-      "name": "entity_gid",
+      "name": "event_gid",
       "type": {"type": "string", "logicalType": "uuid"},
-      "doc": "The entity GID of the semantic event, mirrors base_event_info.entity_gid"
+      "doc": "A unique GID for each message - calculated on the server side from the message ID or other factors if missing"
     },
     {
-      "name": "access",
-      "type": ["null", {"type": "array", "items": "Access"}],
-      "default": null
+      "name": "root_event_gid",
+      "type": {"type": "string", "logicalType": "uuid"},
+      "doc": "Teh root event GID of the event, if this is a derived event (higher order) then this will be populated with the root event GID"
     },
     {
-      "name": "analysis",
-      "type": ["null", {"type": "array", "items": "Analysis"}],
-      "default": null
+      "name": "analyse",
+      "type": ["null", {"type": "map", "values": "boolean"}],
+      "default": null,
+      "doc": "Custom analysis flags that override the default analysis for this event"
     },
     {
-      "name": "app",
-      "type": ["null", {"type": "array", "items": "App"}],
-      "default": null
+      "name": "integrations",
+      "type": ["null", {"type": "map", "values": "boolean"}],
+      "default": null,
+      "doc": "Customer integrations flags that override the default integrations for this event"
     },
     {
-      "name": "campaign",
-      "type": ["null", {"type": "array", "items": "Campaign"}],
-      "default": null
+      "name": "write_key",
+      "type": "string",
+      "doc": "The write key used to send the event (salted hash of the write key) - Internal, can not be set by the user or vie API"
     },
     {
-      "name": "commerce",
-      "type": ["null", {"type": "array", "items": "Commerce"}],
-      "default": null
+      "name": "ttl_days",
+      "type": ["null", "double"],
+      "default": null,
+      "doc": "The number of days the event will be stored in the database (defaults to forever)"
     },
     {
-      "name": "content",
-      "type": ["null", {"type": "array", "items": "Content"}],
-      "default": null
-    },
-    {
-      "name": "context",
-      "type": ["null", {"type": "array", "items": "Context"}],
-      "default": null
-    },
-    {
-      "name": "contextual_awareness",
-      "type": ["null", {"type": "array", "items": "ContextualAwareness"}],
-      "default": null
-    },
-    {
-      "name": "device",
-      "type": ["null", {"type": "array", "items": "Device"}],
-      "default": null
-    },
-    {
-      "name": "embeddings",
-      "type": ["null", {"type": "array", "items": "Embeddings"}],
-      "default": null
-    },
-    {
-      "name": "entity",
-      "type": ["null", {"type": "array", "items": "Entity"}],
-      "default": null
-    },
-    {
-      "name": "id",
-      "type": ["null", {"type": "array", "items": "Id"}],
-      "default": null
-    },
-    {
-      "name": "involved",
-      "type": ["null", {"type": "array", "items": "Involved"}],
-      "default": null
-    },
-    {
-      "name": "library",
-      "type": ["null", {"type": "array", "items": "Library"}],
-      "default": null
-    },
-    {
-      "name": "media",
-      "type": ["null", {"type": "array", "items": "Media"}],
-      "default": null
-    },
-    {
-      "name": "network",
-      "type": ["null", {"type": "array", "items": "Network"}],
-      "default": null
-    },
-    {
-      "name": "os",
-      "type": ["null", {"type": "array", "items": "Os"}],
-      "default": null
-    },
-    {
-      "name": "page",
-      "type": ["null", {"type": "array", "items": "Page"}],
-      "default": null
-    },
-    {
-      "name": "product",
-      "type": ["null", {"type": "array", "items": "Product"}],
-      "default": null
-    },
-    {
-      "name": "referrer",
-      "type": ["null", {"type": "array", "items": "Referrer"}],
-      "default": null
-    },
-    {
-      "name": "screen",
-      "type": ["null", {"type": "array", "items": "Screen"}],
-      "default": null
-    },
-    {
-      "name": "classification",
-      "type": ["null", {"type": "array", "items": "Classification"}],
-      "default": null
-    },
-    {
-      "name": "location",
-      "type": ["null", {"type": "array", "items": "Location"}],
-      "default": null
-    },
-    {
-      "name": "sentiment",
-      "type": ["null", {"type": "array", "items": "Sentiment"}],
-      "default": null
-    },
-    {
-      "name": "source_info",
-      "type": ["null", {"type": "array", "items": "SourceInfo"}],
-      "default": null
-    },
-    {
-      "name": "traits",
-      "type": ["null", {"type": "array", "items": "Traits"}],
-      "default": null
-    },
-    {
-      "name": "uom",
-      "type": ["null", {"type": "array", "items": "Uom"}],
-      "default": null
-    },
-    {
-      "name": "user_agent",
-      "type": ["null", {"type": "array", "items": "UserAgent"}],
-      "default": null
-    },
-    {
-      "name": "user_agent_data",
-      "type": ["null", {"type": "array", "items": "UserAgentData"}],
-      "default": null
+      "name": "partition",
+      "type": "string",
+      "doc": "The version of the event message - Internal, can not be set by the user or vie API"
     }
   ]
 }

--- a/schema/avro/sentiment.avsc
+++ b/schema/avro/sentiment.avsc
@@ -5,20 +5,17 @@
   "fields": [
     {
       "name": "type",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "Type of the sentiment. SQL Enum8('Praise'=1, 'Criticism'=2, 'Complaint'=3, 'Abuse'=4, 'Threat'=5, 'Opinion'=6, 'Other'=0)"
+      "type": "string",
+      "doc": "Enum8('Praise'=1, 'Criticism'=2, 'Complaint'=3, 'Abuse'=4, 'Threat'=5, 'Opinion'=6, 'Other'=0)"
     },
     {
       "name": "sentiment",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The sentiment expressed"
     },
     {
       "name": "entity_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the entity that is involved in the event"
     },
     {
@@ -29,8 +26,7 @@
     },
     {
       "name": "id_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the entity that is involved in the event"
     },
     {
@@ -41,14 +37,12 @@
     },
     {
       "name": "target_category",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The type of the entity that is involved in the event"
     },
     {
       "name": "target_type",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The target type of the sentiment"
     },
     {

--- a/schema/avro/traits.avsc
+++ b/schema/avro/traits.avsc
@@ -5,68 +5,57 @@
   "fields": [
     {
       "name": "id",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The ID of the user"
     },
     {
       "name": "name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The name of the user"
     },
     {
       "name": "first_name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The first name of the user"
     },
     {
       "name": "last_name",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The last name of the user"
     },
     {
       "name": "social_security_nr",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The social security number of the user"
     },
     {
       "name": "social_security_nr_family",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The social security number of the user"
     },
     {
       "name": "email",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The email of the user"
     },
     {
       "name": "phone",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The phone number of the user"
     },
     {
       "name": "avatar",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The avatar of the user"
     },
     {
       "name": "username",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The username of the user"
     },
     {
       "name": "website",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The website of the user"
     },
     {
@@ -89,44 +78,37 @@
     },
     {
       "name": "company",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The company of the user"
     },
     {
       "name": "title",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The title of the user"
     },
     {
       "name": "gender",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "Gender of the user. SQL Enum8(...)"
+      "type": "string",
+      "doc": "Enum8('Male'=1, 'Female'=2, 'Transgender'=3, 'Non-Binary'=4, 'Gender Queer'=5, 'Gender Fluid'=6, 'Gender Neutral'=7, 'Intersex'=8, 'Gender Non-Conforming'=9, 'Gender-Expansive'=10, 'Agender'=11, 'Gendervoid'=12, 'Bigender'=13, 'Omnigender'=14, 'Pangender'=15, 'Two-spirit'=16, 'Trans'=17, 'No Response'=0, ''=99), --"
     },
     {
       "name": "pronouns",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The pronouns of the user"
     },
     {
       "name": "salutation",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The salutation of the user"
     },
     {
       "name": "description",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "A general description of the user"
     },
     {
       "name": "industry",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The industry of the user"
     },
     {
@@ -137,13 +119,12 @@
     },
     {
       "name": "plan",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The plan of the user"
     },
     {
       "name": "total_billed",
-      "type": ["null", "double"],
+      "type": ["null", "float"],
       "default": null,
       "doc": "The total billed of the user"
     },

--- a/schema/avro/user_agent.avsc
+++ b/schema/avro/user_agent.avsc
@@ -4,6 +4,11 @@
   "namespace": "com.contextsuite.schema",
   "fields": [
     {
+      "name": "signature",
+      "type": "string",
+      "doc": "The user agent (e.g. \\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36\\\")"
+    },
+    {
       "name": "mobile",
       "type": ["null", "boolean"],
       "default": null,
@@ -11,21 +16,13 @@
     },
     {
       "name": "platform",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The platform of the user agent (e.g. \\\"Apple Mac\\\")"
     },
     {
-      "name": "signature",
-      "type": ["null", "string"],
-      "default": null,
-      "doc": "The user agent (e.g. \\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36\\\")"
-    },
-    {
       "name": "data",
-      "type": ["null", "com.contextsuite.schema.UserAgentData"],
-      "default": null,
-      "doc": "User agent data including brand and version"
+      "type": {"type": "array", "items": "com.contextsuite.schema.UserAgentData"},
+      "doc": "User agent data including brand and version details for each client hint."
     }
   ]
 }

--- a/schema/avro/user_agent_data.avsc
+++ b/schema/avro/user_agent_data.avsc
@@ -5,14 +5,12 @@
   "fields": [
     {
       "name": "brand",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The brand of the user agent (e.g. \\\"Apple\\\")"
     },
     {
       "name": "version",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
       "doc": "The version of the user agent (e.g. \\\"Mac OS X 10_10_5\\\")"
     }
   ]


### PR DESCRIPTION
…ckHouse as the source of truth.

This synchronizes the Avro schemas in `schema/avro/` with the ClickHouse table definitions in `schema/sql/` (specifically `semantic_events.sql`, `entities.sql`, and `data_points.sql`).

Here's a summary of the key changes:

1.  **Refactored `semantic_event.avsc`:**
    *   I added numerous missing top-level fields from `semantic_events.sql`.
    *   The `content` field is now a `map<string>` instead of an `array<ContentRecord>`.
    *   Fields corresponding to ClickHouse prefixed columns (like `campaign`, `app`, `device`) are now single, nullable records instead of arrays of records.
    *   I removed fields that weren't present in `semantic_events.sql` (for example, top-level `embeddings`, `media`, and the `entity` record array).
    *   I made sure all field `doc` strings match the ClickHouse comments.

2.  **Updated `entity.avsc` and its sub-records (`content.avsc`, `media.avsc`, etc.):**
    *   I primarily updated the `doc` strings to exactly match the comments from `entities.sql`.
    *   I also ensured that field types and nullability align with `entities.sql`.

3.  **Created `data_point.avsc`:**
    *   This is a new Avro schema to represent the `data_points.sql` table. It uses Avro maps for ClickHouse Map types and matches all field definitions and comments.

4.  **Created `base_event_info.avsc`:**
    *   This new Avro schema is for the `base_events` Nested structure found in `semantic_events.sql`.

5.  **Updated all other referenced Avro record definitions:**
    *   I systematically reviewed and updated field names, Avro types, nullability, and `doc` strings to precisely match their corresponding definitions within the ClickHouse schemas (`semantic_events.sql` or `entities.sql`).