### PR TITLE
Enhance documentation for Datapoints

### DIFF
--- a/docs/pages/docs/datapoints/index.md
+++ b/docs/pages/docs/datapoints/index.md
@@ -6,27 +6,148 @@ title: Understanding Datapoints
 
 ## Introduction
 
-A **Datapoint** within the Semantic Event Schema is a specific, granular piece of information, a measurement, or an attribute that provides detailed context about a Semantic Event or an Entity. Think of datapoints as the lowest-level, quantifiable or descriptive details that enrich the understanding of what happened or what an entity is like.
+A **Datapoint** within the Semantic Event Schema represents a specific, granular piece of information, typically a measurement or an attribute, that provides detailed context about a Semantic Event or an Entity at a particular point in time or over a defined period. Think of datapoints as the lowest-level, quantifiable or descriptive details that enrich the understanding of what happened, what an entity is like, or how a metric is changing.
 
-The primary purpose of Datapoints is to offer precise, low-level details necessary for quantification, detailed description, and in-depth analysis. They are the raw facts that, when aggregated and analyzed, lead to meaningful insights.
+The primary purpose of Datapoints is to offer precise, low-level details necessary for quantification, detailed description, timeseries analysis, and in-depth analytics. They are the raw facts that, when aggregated and analyzed, lead to meaningful insights and a deeper understanding of complex systems.
 
 ## Key Characteristics of Datapoints
 
-Datapoints are typically defined by the following characteristics:
+While the detailed schema is covered below, datapoints generally possess these characteristics:
 
 - **Name/Key**: A unique identifier or label for the datapoint (e.g., `page_load_time`, `product_price`, `error_code`). This describes what the datapoint represents.
-- **Value**: The actual recorded data for that datapoint (e.g., `150` for `page_load_time`, `49.99` for `product_price`).
+- **Value**: The actual recorded data for that datapoint (e.g., `150` for `page_load_time_ms`, `49.99` for `product_price_usd`).
 - **Data Type**: The nature of the value, such as number, string, boolean, array, or object. This dictates how the datapoint can be processed and analyzed.
-- **Units (Optional, but Recommended for Numerical Data)**: For numerical data, specifying units is crucial for correct interpretation (e.g., `ms` for time, `USD` for currency, `pixels` for screen dimensions).
-- **Timestamp (Optional)**: In some cases, a datapoint might have its own timestamp indicating when it was recorded or measured, especially if this differs from the overall event timestamp.
+- **Units (Recommended for Numerical Data)**: For numerical data, specifying units is crucial for correct interpretation (e.g., `ms` for time, `USD` for currency, `degrees_celsius` for temperature).
+- **Timestamp**: A specific timestamp indicating when the datapoint was recorded or measured, or the start of the period it represents.
 
 {% .callout type="note" %}
-Consistency in naming conventions (e.g., using `snake_case` for keys) and clear definitions for each datapoint are vital for a maintainable and understandable schema.
+Consistency in naming conventions (e.g., using `snake_case` for keys like `page_load_time_ms`) and clear definitions for each datapoint are vital for a maintainable and understandable schema.
 {% / .callout %}
+
+## Datapoint Schema Fields
+
+The following sections detail the schema of the `data_points` table as typically defined in a ClickHouse SQL schema for timeseries data. Each field is described along with its data type and purpose, providing a comprehensive structure for storing and querying datapoints.
+
+### Timeseries and Entity Identification
+
+These fields link the datapoint to a specific timeseries and the primary entity it describes.
+
+- **`series_gid`** (`LowCardinality(UUID)`): The Global Unique Identifier (GID) of the metric or timeseries this datapoint belongs to. This typically links to an Entity that defines the metric itself (e.g., an entity representing "Average Temperature" or "Website Page Views").
+- **`entity_gid`** (`LowCardinality(UUID)`): The GID of the specific entity that this datapoint is reporting on or is an attribute of (e.g., GID of a specific weather station, a particular product, or a user). This links to an Entity.
+- **`entity_gid_url`** (`LowCardinality(String)`): The GID URL representation for the `entity_gid`, providing a resolvable link to the entity.
+
+### Location Information
+
+Provides geographical context for the datapoint, especially relevant for entities that have a physical location or for events occurring at a specific place.
+
+- **`geohash`** (`LowCardinality(String)`): The geolocation of the entity reported on at the time of the datapoint, represented as a geohash. This is useful for clustering, sorting, and spatial queries.
+    {% .callout type="note" %}
+    For non-stationary entities (e.g., vehicles, mobile users), the `geohash` will change over time with each datapoint, reflecting the entity's movement.
+    {% / .callout %}
+
+### Reporting Period/Intervals
+
+Defines the temporal context of the datapoint, specifying its frequency and the exact time it pertains to.
+
+- **`period`** (`LowCardinality(String)`): The resolution or frequency of the data, expressed in ISO 8601 duration format. This indicates the length of the interval for which the datapoint is valid or aggregated.
+    - Examples: `PT1S` (1 second), `PT1M` (1 minute), `PT1H` (1 hour), `P1D` (1 day), `P1M` (1 month), `P1Y` (1 year).
+- **`timestamp`** (`DateTime`): The calendar date and time (UTC) marking the beginning of the `period` for which the data is reported.
+    {% .callout type="important" %}
+    This is the actual timestamp of the measurement or observation (the start of the interval), not the time the data was ingested into the system.
+    {% / .callout %}
+
+### Ownership and Source
+
+These fields track the provenance of the datapoint, indicating who owns it, where it originated, and who published it. This is crucial for data governance, quality assessment, and attribution. All GIDs link to corresponding Entities.
+
+- **`owner_gid`** (`LowCardinality(UUID)`): The GID of the entity that owns this datapoint (e.g., the organization or department responsible for the data).
+- **`source_gid`** (`LowCardinality(UUID)`): The GID of the entity representing the original source of the data (e.g., a specific sensor, an external data provider, a user input system).
+- **`publisher_gid`** (`LowCardinality(UUID)`): The GID of the entity that published this datapoint (e.g., the platform or system that made the data available).
+- **`publication_gid`** (`LowCardinality(UUID)`): The GID of the specific publication or dataset this datapoint belongs to. This can be useful for versioning or grouping data releases.
+
+### Structured Metadata
+
+These fields allow for enriching datapoints with additional structured, key-value pair information across various domains, providing deeper context. Each field is a `Map(LowCardinality(String), LowCardinality(String))` unless specified otherwise.
+
+- **`gids`** (`Map(LowCardinality(String), LowCardinality(UUID))`): Provides additional links to Named Entities. This can be used to associate the datapoint with other relevant entities beyond the primary `entity_gid`.
+    - Example: `{"related_campaign": "camp_123abc_gid", "influenced_by_event": "evt_xyz789_gid"}` (where values are GIDs).
+- **`location`** (`Map(LowCardinality(String), LowCardinality(String))`): Stores additional geographical details specific to this datapoint, supplementing the primary `geohash`.
+    - Example: `{"venue_section": "A1", "specific_sensor_loc": "Rack 3, Shelf 2"}`.
+- **`demography`** (`Map(LowCardinality(String), LowCardinality(String))`): Adds demographic information relevant to the datapoint.
+    - Example: `{"age_group": "25-34", "user_segment_custom": "tech_enthusiast"}`.
+- **`classification`** (`Map(LowCardinality(String), LowCardinality(String))`): Provides further classification details for the datapoint, beyond general entity classification.
+    - Example: `{"data_sensitivity": "confidential", "quality_tier": "premium"}`.
+- **`topology`** (`Map(LowCardinality(String), LowCardinality(String))`): Describes network or system topology relevant to the datapoint.
+    - Example: `{"server_node": "node_101", "data_center_region": "us-east-1"}`.
+- **`usage`** (`Map(LowCardinality(String), LowCardinality(String))`): Captures details about the usage context of the entity or system related to this datapoint.
+    - Example: `{"user_activity_level": "high", "feature_interaction_intensity": "moderate"}`.
+- **`device`** (`Map(LowCardinality(String), LowCardinality(String))`): Specifies details about the device from which the datapoint was generated or to which it pertains.
+    - Example: `{"device_model": "iPhone 15 Pro", "os_version": "iOS 17.1"}`.
+- **`product`** (`Map(LowCardinality(String), LowCardinality(String))`): Contains additional product-related information relevant to the datapoint.
+    - Example: `{"product_sku": "SKU12345", "product_category_path": "Electronics/Audio/Headphones"}`.
+
+### Flags and Tags
+
+These fields offer flexible ways to add boolean markers (flags) or categorical labels (tags) to datapoints for filtering, grouping, or signaling specific attributes.
+
+- **`flags`** (`Map(LowCardinality(String), BOOLEAN)`): A map of named boolean flags. This allows for setting various binary characteristics for the datapoint.
+    - Example: `{"is_anomaly": true, "needs_review": false, "is_synthetic_data": false}`.
+- **`tags`** (`Array(LowCardinality(String))`): An array of string tags. Tags are useful for applying multiple labels or keywords to a datapoint.
+    - Example: `["critical", "realtime_processed", "customer_facing_metric"]`.
+
+### Core Datapoint Information
+
+These fields store the primary data values of the datapoint, typically as dimensions (descriptive attributes) and metrics (numerical measurements).
+
+- **`dimensions`** (`Map(LowCardinality(String), LowCardinality(String))`): A map of key-value pairs representing the dimensional attributes of the entity or event this datapoint describes. These are typically low-cardinality strings used for grouping, filtering, and segmenting data (e.g., on a dashboard).
+    - Example: `{"country": "US", "device_category": "mobile", "user_status": "active"}`.
+- **`metrics`** (`Map(LowCardinality(String), Float64)`): A map where keys are metric names (e.g., `sales_total`, `active_users`) and values are their corresponding `Float64` measurements. This is where the actual numerical data of the datapoint is stored.
+    - Example: `{"page_views": 1200.0, "cpu_utilization_percent": 75.5, "temperature_celsius": 22.3}`.
+
+### Measurement Details
+
+These fields provide further context about the `metrics`, explaining what they are, their units, and how they should be aggregated. The keys in these maps typically correspond to the metric names defined in the `metrics` field.
+
+- **`mtype`** (`Map(LowCardinality(String), LowCardinality(String))`): Specifies the measurement type for each metric. This can indicate if a metric is a counter (monotonically increasing value), gauge (value can go up or down), rate, etc.
+    - Example: `{"page_views": "counter", "cpu_utilization_percent": "gauge"}`.
+- **`uom`** (`Map(LowCardinality(String), LowCardinality(String))`): Defines the Unit of Measure for each metric.
+    {% .callout type="info" %}
+    It's crucial for consistent interpretation that all Unit of Measure (UOM) values link to a standardized UOM Entity in your entity system (e.g., an entity for "USD", "Count", "Percentage").
+    {% / .callout %}
+    - Example: `{"page_views": "Count", "cpu_utilization_percent": "Percentage", "temperature_celsius": "Degrees Celsius"}`.
+- **`of_what`** (`Map(LowCardinality(String), LowCardinality(String))`): Describes *what* the metric is measuring, often linking to a standard definition or concept (e.g., from Wikidata, DBpedia, or an internal ontology). The key is the metric name, and the value is the standard or concept being measured.
+    - Example: `{"population": "wd:Q11517" (Wikidata item for population), "oil_production": "dbpedia:Oil_production", "humidity": "custom_ontology:RelativeHumidity"}`.
+- **`agg_method`** (`Map(LowCardinality(String), LowCardinality(String))`): Specifies the default aggregation method recommended for each metric when summarizing or rolling up data over time or across dimensions. The key is the metric name.
+    - Example: `{"page_views": "sum", "cpu_utilization_percent": "avg", "temperature_celsius": "max"}`. Common values include `sum`, `avg`, `max`, `min`, `count`.
+
+### Access, Partitioning, and System Fields
+
+These fields are generally system-managed and relate to data access control, storage partitioning, and internal database operations for efficiency and integrity.
+
+- **`signature`** (`UUID`): A UUID signature generated from a combination of the `series_gid`, `dimensions`, `of_what` map, and specific `metrics` keys.
+    {% .callout type="important" %}
+    This signature is used internally by the database (specifically `ReplacingMergeTree` in ClickHouse) to correctly identify and manage updates or replacements of datapoint records, ensuring data integrity for a unique combination of identifying fields.
+    {% / .callout %}
+- **`access_type`** (`Enum8('Local' = 0, 'Exclusive' = 1, 'Group' = 2, 'SharedPercentiles' = 3, 'SharedObfuscated' = 4, 'Shared' = 5, 'Public' = 6) DEFAULT(1)`): An enumerated type that defines the access control level for the datapoint. Default is `Exclusive` (1).
+    - `Local` (0): Data is only accessible locally, not queryable by the broader system.
+    - `Exclusive` (1): Data is exclusive to the owner/source system.
+    - `Group` (2): Data is shared within a defined group or organization.
+    - `SharedPercentiles` (3): Only percentile-based aggregations of the data are shared, not raw values.
+    - `SharedObfuscated` (4): Data is shared in an obfuscated or anonymized form.
+    - `Shared` (5): Data is shared more broadly under specific agreements or entitlements.
+    - `Public` (6): Data is publicly accessible to anyone.
+- **`partition`** (`LowCardinality(String)`): Represents the storage partition key, often derived from the timestamp (e.g., `YYYY-MM` like "2024-01") or another logical grouping. The SQL schema comment "The version of the event message" might imply its use in data versioning or batch identification for partitioning strategies.
+    {% .callout type="info" %}
+    This field is primarily for database performance optimization (reducing data scanned) and data lifecycle management (e.g., dropping old partitions).
+    {% / .callout %}
+- **`sign`** (`Int8 default 1`): An internal field used by ClickHouse's `ReplacingMergeTree` table engine.
+    {% .callout type="info" %}
+    The `sign` field (typically `1` for active records, `-1` for records intended to mark previous versions as deleted during merges) is essential for the engine to correctly process data replacements and maintain the latest version of records. It is not typically set or modified by users directly.
+    {% / .callout %}
 
 ## Common Datapoint Examples
 
-Datapoints can be broadly categorized, and here are some illustrative examples:
+While the schema above defines the structure for storage, datapoints in practice often refer to individual metric values or descriptive attributes. Here are some illustrative examples of what a "datapoint" might conceptually represent:
 
 - **Quantitative Datapoints** (representing measurements):
     - `order_value: 120.50` (with unit "USD")
@@ -49,16 +170,14 @@ Datapoints can be broadly categorized, and here are some illustrative examples:
 
 ## How Datapoints Relate to Events and Entities
 
-Datapoints are typically found as:
+Datapoints are the atomic pieces of information that typically:
 
-1.  **Properties within a Semantic Event's payload**: They provide specific details about the occurrence itself. For example, an `item_viewed` event might include datapoints like `view_duration`, `scroll_depth_percentage`, and `item_price`.
-2.  **Attributes of an Entity**: They describe the characteristics of an entity. For instance, a `user` entity might have datapoints like `total_purchase_count`, `last_login_date`, or `account_status`.
+1.  Are collected as **part of a Semantic Event's payload**: They provide specific details about the occurrence itself. For example, an `item_viewed` event might include datapoints like `view_duration`, `scroll_depth_percentage`, and `item_price` as part of its properties.
+2.  Describe the **attributes or state of an Entity at a point in time**: A `user` entity might have datapoints representing `total_purchase_count`, `last_login_date`, or `account_status`. These can be stored as individual records in the `data_points` table, linked to the user's `entity_gid`.
 
-Essentially, datapoints are the fine-grained pieces of information that populate the attributes of events and entities, making them rich with detail.
+Essentially, datapoints are the fine-grained pieces of information that populate the attributes of events and describe entities, making them rich with detail for analysis.
 
-## Generic Datapoint Structure Example
-
-Datapoints often reside within a properties object of an event or an entity. Here’s a conceptual JSON example showing datapoints within an "Item Added to Cart" event:
+## Benefits of Well-Defined Datapoints
 
 ```json
 {
@@ -79,10 +198,92 @@ Datapoints often reside within a properties object of an event or an entity. Her
 ```
 
 {% .callout type="info" %}
-**Note:** This is a conceptual illustration. The specific field names (e.g., `properties`) and the location of datapoints can vary based on the schema implementation. The core idea is that events and entities carry these granular pieces of information.
+**Note:** The JSON above is a conceptual illustration of how datapoints might appear within an event's properties. The `data_points` table schema described earlier is designed for storing these granular facts in a structured timeseries database.
 {% / .callout %}
 
-## Benefits of Well-Defined Datapoints
+## Generic Datapoint Structure Example
+
+The following is an example of a single datapoint record as it might be stored in the `data_points` table, reflecting the schema fields described above:
+
+```json
+{
+  "series_gid": "ts_01h4g3f2j1k0p0n8m7q5r4e3w2a1s0d1",
+  "entity_gid": "ent_a1b2c3d4-e5f6-7890-1234-567890abcdef",
+  "entity_gid_url": "nova://entities/ent_a1b2c3d4-e5f6-7890-1234-567890abcdef",
+  "geohash": "u4pruydqqvj",
+  "period": "PT1H",
+  "timestamp": "2024-01-15T14:00:00Z",
+  "owner_gid": "org_k9l8m7n6-p5o4-3210-fedc-ba0987654321",
+  "source_gid": "src_z1y2x3w4-v5u6-7890-abcd-ef1234567890",
+  "publisher_gid": "pub_s9r8q7p6-o5n4-m3l2-k1j0-ihgfedcba987",
+  "publication_gid": "pubset_f1e2d3c4-b5a6-0987-7654-3210fedcba09",
+  "dimensions": {
+    "region": "emea",
+    "product_category": "electronics"
+  },
+  "metrics": {
+    "sales_total": 15750.75,
+    "active_users": 12345.0
+  },
+  "mtype": {
+    "sales_total": "gauge",
+    "active_users": "gauge"
+  },
+  "uom": {
+    "sales_total": "USD",
+    "active_users": "count"
+  },
+  "of_what": {
+    "sales_total": "concept:TotalRevenue",
+    "active_users": "concept:ActiveUserCount"
+  },
+  "agg_method": {
+    "sales_total": "sum",
+    "active_users": "sum"
+  },
+  "gids": {
+    "promotion_applied": "promo_smmr24_q12w"
+  },
+  "location": {
+    "store_id": "STR0123",
+    "country_iso": "DE"
+  },
+  "demography": {
+    "age_bracket": "25-35"
+  },
+  "classification": {
+    "customer_segment": "premium"
+  },
+  "topology": {
+    "server_farm": "farm_eu_west_03"
+  },
+  "usage": {
+    "data_plan": "unlimited"
+  },
+  "device": {
+    "os_type": "android"
+  },
+  "product": {
+    "product_id": "PRDXYZ789"
+  },
+  "flags": {
+    "is_forecast_data": false,
+    "is_aggregated": true
+  },
+  "tags": [
+    "hourly_rollup",
+    "emea_sales_data",
+    "electronics_department"
+  ],
+  "signature": "sig_0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+  "access_type": 5,
+  "partition": "2024-01",
+  "sign": 1
+}
+```
+{% .callout type="note" %}
+In this example, `access_type: 5` corresponds to 'Shared'. The `sign` and `partition` fields are typically managed by the system. This structure provides a rich, detailed view of a single datapoint, ready for complex analytics and timeseries analysis.
+{% / .callout %}
 
 Incorporating well-defined datapoints into your semantic event and entity structures offers significant benefits:
 

--- a/docs/pages/docs/entities/index.md
+++ b/docs/pages/docs/entities/index.md
@@ -14,7 +14,7 @@ The primary purpose of defining Entities is to contextualize Semantic Events and
 
 Entities are typically defined by several key characteristics:
 
-- **Unique Identifier**: This is essential for distinguishing one entity from another. It could be a specific field like `entity_id`, `user_id`, or a composite key, depending on the entity type and system design. The concept of a unique ID is more important than the specific field name.
+- **Unique Identifier**: This is essential for distinguishing one entity from another. It could be a specific field like an entity ID (e.g., `gid`), user ID, or a composite key, depending on the entity type and system design. The concept of a unique ID is more important than the specific field name.
 - **Entity Type**: This is a classification that defines the nature of the entity (e.g., "user", "product", "session", "order"). It helps in categorizing and filtering entities.
 - **Properties/Attributes**: These are key-value pairs that describe the characteristics of the entity. For example, a "product" entity might have properties like `name`, `category`, `brand`, and `price`.
 - **(Optional) Relationships**: Entities can also have relationships with other entities. For instance, an "order" entity might be related to a "user" entity and multiple "product" entities. While not always explicitly part of the core entity definition within an event, these relationships are often modeled in the broader data ecosystem.
@@ -23,59 +23,323 @@ Entities are typically defined by several key characteristics:
 While specific field names for identifiers and types might vary based on implementation, the conceptual roles of these characteristics remain consistent.
 {% / .callout %}
 
-## Common Entity Examples
+## Entity Schema Fields
 
-Here are some common types of entities encountered in semantic event data:
+This section details the standard fields available in the entity schema.
 
-- **User/Customer**: Represents an individual interacting with a system or service (e.g., `entity_type: "user"`). Attributes might include `email`, `name`, `loyalty_status`.
-- **Product**: Represents an item or service offered (e.g., `entity_type: "product"`). Attributes could be `sku`, `name`, `description`, `price`.
-- **Order/Transaction**: Represents a specific transaction or engagement (e.g., `entity_type: "order"`). Attributes might include `order_id`, `total_amount`, `status`.
-- **Organization**: Represents a company, business unit, or group (e.g., `entity_type: "organization"`). Attributes could include `name`, `industry`, `location`.
-- **Device**: Represents a physical or virtual device used (e.g., `entity_type: "device"`). Attributes might include `device_id`, `model`, `os_version`.
+### Core Identification Fields
 
-## How Entities Relate to Semantic Events
+- **`gid`** (`UUID`): The Graph UUID of the entity. This serves as the primary, unique identifier for the entity across systems.
+- **`gid_url`** (`String`): The URL representation of the entity's `gid`.
 
-Semantic Events typically link to one or more entities to provide full context. The event data itself will often contain identifiers for the involved entities. For example:
+### Descriptive & Categorization Fields
 
-- A **'Product Purchased'** event would link to a 'user' entity (who made the purchase) and one or more 'product' entities (what was purchased).
-- A **'Support Ticket Created'** event might link to a 'user' entity (who created the ticket) and potentially an 'agent' entity (if assigned).
+- **`label`** (`String`): The primary human-readable label for the entity (e.g., "Eiffel Tower", "John Doe Concert").
+- **`labels`** (`Array(LowCardinality(String))`): Additional labels for the entity, often with language prefixes to support multilingual representations (e.g., `["en:Eiffel Tower", "fr:Tour Eiffel"]`).
+- **`type`** (`LowCardinality(String)`): The primary type of the entity (e.g., "Event", "Place", "Person", "Organization").
+    {% .callout type="note" %}
+    The `type` field should always be in English, singular form, and capitalized (e.g., "Event", not "events").
+    {% / .callout %}
+- **`variant`** (`LowCardinality(String)`): A more specific variant or sub-type of the entity (e.g., for `type: "Event"`, `variant` could be "Concert", "Exhibition", "Match").
+    {% .callout type="note" %}
+    The `variant` field should always be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`icon`** (`LowCardinality(String)`): An icon identifier associated with the entity, often used for UI purposes (e.g., "concert", "exhibition", "match").
+    {% .callout type="note" %}
+    The `icon` field should always be in English, singular form, and typically lowercase, though capitalization rules might vary by implementation. The SQL schema comment specifies capitalized, but common usage is often lowercase for icon names. For consistency with `type` and `variant` as per SQL schema, it's listed as capitalized here.
+    {% / .callout %}
+- **`colour`** (`LowCardinality(String)`): A colour associated with the entity, often used for UI categorization or visual cues (e.g., "Red", "Blue", "Green").
+    {% .callout type="note" %}
+    The `colour` field should always be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`dimensions`** (`Map(LowCardinality(String), LowCardinality(String))`): Generic additional dimensions for the entity, allowing for flexible key-value pair characterization (e.g., `{"product_line": "premium", "target_audience": "young_adults"}`).
+- **`tags`** (`Array(LowCardinality(String))`): Additional tags for the entity, used for categorization, filtering, or grouping (e.g., `["outdoor", "summer_event", "family_friendly"]`).
+- **`flags`** (`Map(LowCardinality(String), BOOLEAN)`): Additional boolean flags for the entity, representing specific characteristics or states (e.g., `{"isFeatured": true, "hasAccessibility": false}`).
+- **`metrics`** (`Map(LowCardinality(String), Float64)`): Additional numerical metrics associated with the entity (e.g., `{"satisfaction_score": 4.5, "completion_rate": 0.85}`).
+- **`properties`** (`Map(LowCardinality(String), LowCardinality(String))`): Additional descriptive key-value properties for the entity. Similar to `dimensions`, but can be used for more varied or less structured data.
+- **`names`** (`Map(LowCardinality(String), LowCardinality(String))`): Additional names or translations for the entity, often used to map internal names to display names or provide alternative identifiers (e.g., `{"internal_sku": "PROD123XYZ", "french_name": "Tour Eiffel"}`).
 
-Sometimes, the role of an entity within an event is also specified, particularly if an event involves multiple entities of the same type (e.g., a 'funds_transferred' event might involve a 'sender_user' and a 'receiver_user').
+### Content Fields (Nested Structure)
+
+The `content` field is a nested structure that allows for storing various textual descriptions and information related to the entity. Each element in the `content` array is an object with the following sub-fields:
+
+- **`label`** (`LowCardinality(String)`): The label identifying this piece of content (e.g., "Prologue", "Synopsis", "Description", "Summary", "Terms and Conditions", "ArtistBiography").
+- **`type`** (`LowCardinality(String)`): Enumerated type classification for the content. Examples from schema: `Description` (1), `Summary` (2), `Conditions` (3), `History` (4), or `Other` (0).
+- **`sub_type`** (`LowCardinality(String)`): Enumerated sub-type for the content. Examples from schema: `short` (1), `long` (2), or `other` (0).
+- **`value`** (`String`): The actual textual content itself.
+- **`meta_description`** (`String`): A description of this content's purpose, context, or questions it might answer.
+- **`language`** (`LowCardinality(String)`): The primary language of the `value`.
+    {% .callout type="note" %}
+    The `language` field should be a 2-letter ISO language code (e.g., "en", "fr", "es").
+    {% / .callout %}
+
+### Media Fields (Nested Structure)
+
+The `media` field is a nested structure for associating various media files (images, videos, audio) with the entity. Each element in the `media` array is an object with the following sub-fields:
+
+- **`media_type`** (`LowCardinality(String)`): The general type of media (e.g., "Image", "Video", "Audio").
+- **`type`** (`LowCardinality(String)`): A more specific type for the media, indicating its purpose (e.g., "Poster", "Thumbnail", "Banner", "Trailer").
+- **`sub_type`** (`LowCardinality(String)`): An even more specific sub-type, often related to hierarchical content or usage context (e.g., "ProgramImage", "SeasonPoster", "EpisodeThumbnail").
+- **`url`** (`String`): The fully qualified URL where the media file can be accessed.
+- **`language`** (`LowCardinality(String)`): The primary language of the media content (e.g., for subtitles in a video, or language-specific imagery).
+    {% .callout type="note" %}
+    The `language` field, when applicable, should be a 2-letter ISO language code.
+    {% / .callout %}
+- **`aspect_ratio`** (`LowCardinality(String)`): The aspect ratio of the media (e.g., "16:9", "4:3", "1:1").
+
+### Embedding Fields (Nested Structure)
+
+The `embeddings` field is a nested structure used to store vector embeddings of the entity's content. These are crucial for similarity searches, recommendations, and other machine learning applications. Each element in the `embeddings` array is an object with these sub-fields:
+
+- **`label`** (`LowCardinality(String)`): A label for the embedding, typically matching a `content.label` from which the embedding was derived (e.g., "SynopsisEmbedding", "DescriptionVector").
+- **`content_starts`** (`LowCardinality(String)`): Optional text prefix used during the embedding generation process (e.g., "Title: ", "Description: "). This helps in providing context to the embedding model.
+- **`content_ends`** (`LowCardinality(String)`): Optional text suffix used during embedding generation (e.g., " ", ".", " - ").
+- **`opening_phrase`** (`LowCardinality(String)`): An optional opening phrase used to frame the content for the embedding model (e.g., "This text describes: ").
+- **`closing_phrase`** (`LowCardinality(String)`): An optional closing phrase used to frame the content for the embedding model (e.g., " End of content.").
+- **`vectors`** (`Array(Float64)`): The actual embedding vectors, represented as an array of floating-point numbers (e.g., typically 1024 or 1536 dimensions depending on the model).
+- **`model`** (`LowCardinality(String)`): The name or identifier of the machine learning model used to generate these embeddings (e.g., "text-embedding-3-small", "openai-clip-base").
+
+### ID Fields (Nested Structure)
+
+The `ids` field is a nested structure that stores various external or alternative identifiers related to the entity itself or other entities involved in an event or relationship. Each element in the `ids` array is an object with the following sub-fields:
+
+- **`label`** (`Nullable(String)`): A descriptive label for this identifier (e.g., "TicketingSystemID", "OrganizerRef", "ISAN").
+- **`role`** (`LowCardinality(String)`): The role this identifier plays, especially in the context of an event or relationship (e.g., "PrimaryContact", "VenueProvider").
+- **`entity_type`** (`LowCardinality(String)`): The type of the entity that this ID refers to (e.g., "User", "Venue", "Promoter").
+- **`entity_gid`** (`Nullable(UUID)`): If this ID refers to another entity tracked within the same system, its `gid` can be stored here.
+- **`id`** (`Nullable(String)`): The actual identifier string (e.g., "XF-12345", "user_789", "venue_abc").
+- **`id_type`** (`LowCardinality(String)`): The type or source system of the `id` (e.g., "CRM_ID", "LegacySystemID", "ISBN").
+- **`capacity`** (`Nullable(Float)`): Represents a capacity associated with this ID, if applicable (e.g., number of tickets allocated to a distributor, seating capacity of a referenced venue section).
+
+### Classification Fields (Nested Structure)
+
+The `classification` field is a nested structure for applying formal or informal categorizations to the entity. Each element in the `classification` array is an object with these sub-fields:
+
+- **`type`** (`LowCardinality(String)`): The classification scheme or category type (e.g., "Genre", "AudienceRating", "ContentWarning").
+- **`value`** (`LowCardinality(String)`): The specific value within the classification scheme (e.g., "Sports->Football", "Concert->Pop", "AgeRating->18+").
+- **`babelnet_id`** (`LowCardinality(String)`): The BabelNet concept ID for the classification term. This aids in semantic understanding, translation, and linking to external knowledge bases.
+- **`weight`** (`Float`): The relevance, confidence, or applicability score of this classification to the entity (e.g., a value between 0.0 and 1.0).
+
+### Location Fields (Nested Structure)
+
+The `location` field is a nested structure detailing geographical information pertinent to the entity. This can represent the entity's own location, the location of an event, or other relevant geographical data. Each element in the `location` array is an object with the following sub-fields:
+
+- **`type`** (`LowCardinality(String)`): The type of location (e.g., "PrimaryAddress", "Venue", "RegisteredOffice", "AreaOfOperation").
+- **`label`** (`LowCardinality(String)`): A human-readable label for this location entry (e.g., "Event Venue", "Artist's Studio").
+- **`country`** (`LowCardinality(String)`): The country of the location.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized (e.g., "France", "United States").
+    {% / .callout %}
+- **`country_code`** (`LowCardinality(String)`): The 3-letter ISO country code.
+    {% .callout type="note" %}
+    Should be in uppercase (e.g., "FRA", "USA").
+    {% / .callout %}
+- **`code`** (`LowCardinality(String)`): A specific administrative or location code (e.g., a state code, district code, or custom internal code).
+    {% .callout type="note" %}
+    Typically in uppercase.
+    {% / .callout %}
+- **`region`** (`LowCardinality(String)`): The region or state.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`division`** (`LowCardinality(String)`): A sub-division like a county, province, or department.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`municipality`** (`LowCardinality(String)`): The city, town, or municipality.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`locality`** (`LowCardinality(String)`): A more specific locality, district, or neighborhood.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`postal_code`** (`LowCardinality(String)`): The postal or ZIP code.
+    {% .callout type="note" %}
+    Typically in uppercase.
+    {% / .callout %}
+- **`postal_name`** (`LowCardinality(String)`): The name of the postal code area or district.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`street`** (`LowCardinality(String)`): The street name.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized.
+    {% / .callout %}
+- **`street_nr`** (`Nullable(String)`): The street number.
+    {% .callout type="note" %}
+    Typically in uppercase.
+    {% / .callout %}
+- **`address`** (`Nullable(String)`): The full, formatted address string.
+    {% .callout type="note" %}
+    Should be in English, singular form, and capitalized if it represents a formal address line.
+    {% / .callout %}
+- **`longitude`** (`Nullable(Float64)`): The geographical longitude in decimal degrees.
+- **`latitude`** (`Nullable(Float64)`): The geographical latitude in decimal degrees.
+- **`geohash`** (`Nullable(String)`): The geohash representation of the location's coordinates.
+    {% .callout type="note" %}
+    Should be in lowercase.
+    {% / .callout %}
+- **`duration_from`** (`Nullable(DateTime64)`): The start date and time for which this location information is valid or relevant.
+- **`duration_until`** (`Nullable(DateTime64)`): The end date and time for which this location information is valid or relevant.
+
+### Internal/System Fields
+
+These fields are primarily used internally by the data storage system (e.g., ClickHouse) for data management, versioning, and integrity.
+
+- **`partition`** (`LowCardinality(String)`): The storage partition for the entity.
+    {% .callout type="info" %}
+    This is an internal field and is not typically submitted by users. It's used to partition data for performance and scalability.
+    {% / .callout %}
+- **`sign`** (`Int8` default 1): An internal field used by ClickHouse's `ReplacingMergeTree` engine.
+    {% .callout type="info" %}
+    This field helps manage updates and ensure data consistency by marking the latest version of an entity. It is not typically set or modified by users.
+    {% / .callout %}
 
 ## Generic Entity Structure Example
 
-While the exact structure and field names can vary, here is a conceptual example of what a "product" entity might look like, represented in JSON:
+Here is a conceptual example of what a "MusicFestival" entity might look like, represented in JSON, showcasing various fields:
 
 ```json
 {
-  "entity_id": "prod_12345",
-  "entity_type": "product",
-  "properties": {
-    "name": "Wireless Noise-Cancelling Headphones",
-    "category": "Electronics",
-    "brand": "SoundWave",
-    "price": 199.99,
-    "currency": "USD",
-    "attributes": {
-      "color": "Black",
-      "weight_grams": 250
+  "gid": "evt_2a7d9f8b-c1e3-4b5f-8a6d-0e2f1c9a7b4d",
+  "gid_url": "nova://entities/evt_2a7d9f8b-c1e3-4b5f-8a6d-0e2f1c9a7b4d",
+  "label": "Nova Summer Fest 2024",
+  "labels": ["en:Nova Summer Fest 2024", "fr:Festival d'été Nova 2024"],
+  "type": "Event",
+  "variant": "MusicFestival",
+  "icon": "MusicFestival",
+  "colour": "Blue",
+  "dimensions": {
+    "expected_attendance": "50000",
+    "duration_days": "3",
+    "event_genre": "MultiGenre"
+  },
+  "tags": ["music", "festival", "summer", "outdoor", "live_acts"],
+  "flags": {
+    "isFamilyFriendly": true,
+    "isSoldOut": false,
+    "allowsCamping": true
+  },
+  "metrics": {
+    "artist_count": 150,
+    "stage_count": 5
+  },
+  "names": {
+    "short_name": "NSF24",
+    "promotional_name": "The Ultimate Nova Summer Festival Experience"
+  },
+  "content": [
+    {
+      "label": "MainDescription",
+      "type": "Description",
+      "sub_type": "long",
+      "value": "Join us for the 10th anniversary of Nova Summer Fest! Three days of incredible music, art installations, and gourmet food under the summer sky.",
+      "meta_description": "Official long description of the Nova Summer Fest 2024, highlighting key features and attractions.",
+      "language": "en"
+    },
+    {
+      "label": "LineupHighlights",
+      "type": "Summary",
+      "sub_type": "short",
+      "value": "Featuring headliners: The Cosmic Keys, Digital Dreams, Acoustic Echoes, and many more across 5 stages.",
+      "meta_description": "Short summary of headlining acts.",
+      "language": "en"
     }
-  }
+  ],
+  "media": [
+    {
+      "media_type": "Image",
+      "type": "Poster",
+      "sub_type": "OfficialEventPoster",
+      "url": "https://example.com/media/nsf2024_poster.jpg",
+      "language": "en",
+      "aspect_ratio": "2:3"
+    },
+    {
+      "media_type": "Video",
+      "type": "Trailer",
+      "sub_type": "OfficialTrailer",
+      "url": "https://youtube.com/watch?v=nsf2024_trailer",
+      "language": "en",
+      "aspect_ratio": "16:9"
+    }
+  ],
+  "ids": [
+    {
+      "label": "TicketingPartnerID",
+      "role": "TicketingProvider",
+      "entity_type": "Organization",
+      "id": "TICKETMASTER_EVT_NSF2024",
+      "id_type": "PartnerEventID"
+    },
+    {
+      "label": "MainOrganizerGID",
+      "role": "Organizer",
+      "entity_type": "Organization",
+      "entity_gid": "org_f1c0a0d0-b0e0-40d0-80c0-00b0a0d0e0f0",
+      "id_type": "NovaGID"
+    }
+  ],
+  "classification": [
+    {
+      "type": "EventGenre",
+      "value": "Music->Electronic",
+      "babelnet_id": "bn:00030922n",
+      "weight": 0.8
+    },
+    {
+      "type": "EventGenre",
+      "value": "Music->Rock",
+      "babelnet_id": "bn:00069047n",
+      "weight": 0.6
+    }
+  ],
+  "location": [
+    {
+      "type": "PrimaryVenue",
+      "label": "Sunshine Park Festival Grounds",
+      "country": "United States",
+      "country_code": "USA",
+      "region": "California",
+      "municipality": "Meadowville",
+      "postal_code": "90210",
+      "street": "123 Festival Lane",
+      "address": "123 Festival Lane, Meadowville, CA 90210, USA",
+      "longitude": -118.4000,
+      "latitude": 34.0500,
+      "geohash": "9q5cs",
+      "duration_from": "2024-07-19T09:00:00Z",
+      "duration_until": "2024-07-21T23:59:59Z"
+    }
+  ],
+  "partition": "2024-07",
+  "sign": 1
 }
 ```
 
 {% .callout type="info" %}
-**Note:** This is a conceptual illustration. Specific field names (e.g., `entity_id`, `properties`) and the overall structure may differ based on the chosen schema implementation or platform. The key is the ability to uniquely identify, type, and describe the entity.
+**Note:** This is a conceptual illustration. The `partition` and `sign` fields are typically system-managed. Specific field names (e.g., `entity_id` vs `gid`) and the overall structure may differ based on the chosen schema implementation or platform. The key is the ability to uniquely identify, type, and describe the entity with rich contextual information.
 {% / .callout %}
+
+## How Entities Relate to Semantic Events
+
+Semantic Events typically link to one or more entities to provide full context. The event data itself will often contain identifiers (like `gid`) for the involved entities. For example:
+
+- A **'Product Purchased'** event would link to a 'User' entity (who made the purchase) and one or more 'Product' entities (what was purchased).
+- A **'Support Ticket Created'** event might link to a 'User' entity (who created the ticket) and potentially an 'Agent' entity (if assigned).
+
+Sometimes, the role of an entity within an event is also specified, particularly if an event involves multiple entities of the same type (e.g., a 'Funds Transferred' event might involve a 'SenderUser' and a 'ReceiverUser', both being 'User' entity types but with different roles in the event). The `ids` nested structure within an entity can also be used to model relationships or roles with other entities.
 
 ## Benefits of Well-Defined Entities
 
 Clearly defining and utilizing entities within your semantic event framework offers several advantages:
 
 - **Deeper Event Understanding**: Entities provide the "who" and "what" for events, making them much richer and more interpretable.
-- **Robust Entity-Centric Analytics**: Allows for tracking behavior, trends, and patterns related to specific users, products, etc., over time.
-- **Building a Connected Data View**: Enables the creation of a graph or network of interconnected entities and events, reflecting complex business processes.
-- **Personalization and Targeting**: Well-defined user entities are fundamental for delivering personalized experiences.
-- **Improved Data Governance**: Clear entity definitions aid in managing data quality, consistency, and compliance.
+- **Robust Entity-Centric Analytics**: Allows for tracking behavior, trends, and patterns related to specific users, products, organizations, etc., over time.
+- **Building a Connected Data View**: Enables the creation of a graph or network of interconnected entities and events, reflecting complex business processes and relationships.
+- **Personalization and Targeting**: Well-defined user and product entities are fundamental for delivering personalized experiences and targeted campaigns.
+- **Improved Data Governance**: Clear entity definitions aid in managing data quality, consistency, compliance, and understanding data lineage.
+- **Enhanced Machine Learning Capabilities**: Rich entity features and embeddings power more accurate recommendations, predictions, and insights.
 
-By consistently identifying and describing entities, organizations can unlock more profound insights from their event data and build more intelligent systems.
+By consistently identifying and describing entities with a comprehensive schema, organizations can unlock more profound insights from their event data and build more intelligent, data-driven systems.


### PR DESCRIPTION
This commit significantly improves the documentation for Datapoints, located at `docs/pages/docs/datapoints/index.md`. The update mirrors the recent enhancements made to the Entities documentation.

Key improvements include:
- Addition of a new "Datapoint Schema Fields" section, detailing every field from the `data_points` SQL schema (`schema/sql/data_points.sql`). This includes descriptions, data types, SQL comments, and usage notes for each field.
- Logical grouping of schema fields into subsections (e.g., Timeseries and Entity Identification, Location Information, Core Datapoint Information, Measurement Details).
- Use of Markdoc callouts to highlight important constraints and field characteristics.
- Revision of the "Generic Datapoint Structure Example" with a comprehensive JSON object that accurately reflects the `data_points` table schema.
- Overall review and refinement for clarity, accuracy, consistency with other documentation, and Markdoc best practices.
- The page title "Understanding Datapoints" is suitable for navigation, and its location ensures inclusion in the site menu.