### PR TITLE
I will continue to generate JSON schemas for shared nested objects.

### DIFF
--- a/schema/json-schema/app_schema.json
+++ b/schema/json-schema/app_schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/app_schema.json",
+  "title": "ContextSuite Semantic Event Application",
+  "description": "Schema for mobile application information.",
+  "type": ["null", "object"],
+  "properties": {
+    "build": { "type": ["null", "string"], "description": "The build of the app (e.g. \"1.1.0\")." },
+    "name": { "type": ["null", "string"], "description": "The name of the app (e.g. \"Segment\")." },
+    "namespace": { "type": ["null", "string"], "description": "The namespace of the app (e.g. \"com.segment.analytics\")." },
+    "version": { "type": ["null", "string"], "description": "The version of the app (e.g. \"1.1.0\")." }
+  },
+  "additionalProperties": false
+}

--- a/schema/json-schema/campaign_schema.json
+++ b/schema/json-schema/campaign_schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/campaign_schema.json",
+  "title": "ContextSuite Semantic Event Campaign",
+  "description": "Schema for marketing campaign information.",
+  "type": ["null", "object"],
+  "properties": {
+    "campaign": { "type": ["null", "string"], "description": "The campaign name (e.g. \"summer\")." },
+    "source": { "type": ["null", "string"], "description": "The source of the campaign (e.g. \"google\")." },
+    "medium": { "type": ["null", "string"], "description": "The medium of the campaign (e.g. \"cpc\")." },
+    "term": { "type": ["null", "string"], "description": "The term associated with the campaign (e.g. \"beach\")." },
+    "content": { "type": ["null", "string"], "description": "The content of the campaign (e.g. \"ad1\")." }
+  },
+  "additionalProperties": false
+}

--- a/schema/json-schema/classification_schema.json
+++ b/schema/json-schema/classification_schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/classification_schema.json",
+  "title": "ContextSuite Classification",
+  "description": "Schema for classification information, usable for entities and events.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The type of classification (e.g., 'Intent', 'Category', 'Tag'). For entities, this might be 'event category->subcategory'.",
+      "type": "string"
+    },
+    "value": {
+      "description": "The value of the classification (e.g., 'Sports->Football', 'Order Inquiry').",
+      "type": "string"
+    },
+    "babelnet_id": {
+      "description": "BabelNet ID for the classification concept (primarily for entities).",
+      "type": ["null", "string"]
+    },
+    "reasoning": {
+      "description": "The reasoning behind the classification (primarily for semantic events).",
+      "type": ["null", "string"]
+    },
+    "score": {
+      "description": "The score of the classification (primarily for semantic events).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "confidence": {
+      "description": "The confidence of the classification from a model (primarily for semantic events).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "weight": {
+      "description": "The relevance of the classification.",
+      "type": "number",
+      "format": "float",
+      "default": 0.0
+    }
+  },
+  "required": [
+    "type",
+    "value"
+  ]
+}

--- a/schema/json-schema/content_schema.json
+++ b/schema/json-schema/content_schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/content_schema.json",
+  "title": "ContextSuite Entity Content",
+  "description": "Schema for a content item associated with an entity.",
+  "type": "object",
+  "properties": {
+    "label": {
+      "description": "The label of the content (e.g. \"Prologue\", \"Synopsis\")",
+      "type": "string"
+    },
+    "type": {
+      "description": "Type of the content, e.g., Description, Summary. SQL Enum8('Description'=1, 'Summary'=2, 'Conditions'=3, 'History'=4, 'Other'=0)",
+      "type": "string"
+    },
+    "sub_type": {
+      "description": "Sub-type of the content, e.g., short, long. SQL Enum8('short'=1, 'long'=2, 'other'=0)",
+      "type": ["null", "string"]
+    },
+    "value": {
+      "description": "The actual content value.",
+      "type": "string"
+    },
+    "language": {
+      "description": "The primary language of the content (2 letter ISO code).",
+      "type": ["null", "string"]
+    },
+    "meta_description": {
+      "description": "A description of the content's purpose.",
+      "type": ["null", "string"]
+    }
+  },
+  "required": [
+    "label",
+    "type",
+    "value"
+  ]
+}

--- a/schema/json-schema/contextual_awareness_schema.json
+++ b/schema/json-schema/contextual_awareness_schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/contextual_awareness_schema.json",
+  "title": "ContextSuite Semantic Event Contextual Awareness",
+  "description": "Schema for contextual awareness information related to an entity in a semantic event.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of contextual information (e.g., Description, Summary, Conditions).",
+      "type": "string"
+    },
+    "entity_type": {
+      "description": "The type of the entity this context refers to (e.g., 'Currency', 'Product').",
+      "type": "string"
+    },
+    "entity_gid": {
+      "description": "The Graph UUID of the entity this context refers to.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "entity_wid": {
+      "description": "The Wikidata ID of the entity this context refers to.",
+      "type": ["null", "string"]
+    },
+    "context": {
+      "description": "The actual contextual information string.",
+      "type": ["null", "string"]
+    }
+  },
+  "required": [
+    "type",
+    "entity_type"
+  ]
+}

--- a/schema/json-schema/cxs_schema.json
+++ b/schema/json-schema/cxs_schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/cxs_schema.json",
+  "title": "ContextSuite Root Schema",
+  "description": "Root schema for all ContextSuite data types. It references individual schemas for entities, semantic events, etc.",
+  "type": "object",
+  "properties": {
+    "entity": {
+      "$ref": "entity.json"
+    },
+    "semantic_event": {
+      "$ref": "semantic_event.json"
+    },
+    "time_series": {
+      "$ref": "timeseries.json"
+    },
+    "data_point": {
+      "$ref": "data_point.json"
+    },
+    "uom": {
+      "$ref": "uom.json"
+    }
+  }
+}

--- a/schema/json-schema/data_point.json
+++ b/schema/json-schema/data_point.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/data_point.json",
+  "title": "ContextSuite Data Point",
+  "description": "Schema for an individual Data Point within a Time Series.",
+  "type": "object",
+  "properties": {
+    "series_gid": {
+      "description": "The GID of the time series this data point belongs to.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "entity_gid": {
+      "description": "GID for the entity that the datapoint belongs to.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "entity_gid_url": {
+      "description": "GID URL for the entity that the datapoint belongs to.",
+      "type": ["null", "string"],
+      "format": "uri"
+    },
+    "geohash": {
+      "description": "Geolocation as a geohash.",
+      "type": ["null", "string"]
+    },
+    "period": {
+      "description": "The resolution/frequency of the data (e.g., 'PT1H', 'P1D').",
+      "type": ["null", "string"]
+    },
+    "timestamp": {
+      "description": "The start of the period for which the data is reported (UTC).",
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner_gid": { "type": ["null", "string"], "format": "uuid" },
+    "source_gid": { "type": ["null", "string"], "format": "uuid" },
+    "publisher_gid": { "type": ["null", "string"], "format": "uuid" },
+    "publication_gid": { "type": ["null", "string"], "format": "uuid" },
+    "gids": {
+      "description": "Additional links to Named Entities.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string", "format": "uuid" }
+    },
+    "location": {
+      "description": "Additional geography for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "demography": {
+      "description": "Additional demography for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "classification": {
+      "description": "Additional classification for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "topology": {
+      "description": "Additional topology for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "usage": {
+      "description": "Additional usage for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "device": {
+      "description": "Additional device for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "product": {
+      "description": "Additional product for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "flags": {
+      "description": "Additional flags for the datapoint.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "boolean" }
+    },
+    "tags": {
+      "description": "Additional tags for the datapoint.",
+      "type": ["null", "array"],
+      "items": { "type": "string" }
+    },
+    "dimensions": {
+      "description": "Dimensions for the entity.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "metrics": {
+      "description": "Metrics for the datapoint - the measurement.",
+      "type": "object",
+      "additionalProperties": { "type": "number", "format": "double" }
+    },
+    "mtype": {
+      "description": "The measurement type for a metric.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "uom": {
+      "description": "Unit of measure for the metrics.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "of_what": {
+      "description": "What the metric is measuring (e.g., 'population').",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "agg_method": {
+      "description": "Default aggregation method for the metric.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "access_type": {
+      "description": "Access type for the data point.",
+      "type": ["null", "string"],
+      "enum": [null, "Local", "Exclusive", "Group", "SharedPercentiles", "SharedObfuscated", "Shared", "Public"],
+      "default": "Exclusive"
+    },
+    "signature": {
+      "description": "Signature for ensuring correct updates/replacements.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "partition": {
+      "description": "Partition key for the data point.",
+      "type": ["null", "string"]
+    },
+    "sign": {
+      "description": "Sign for ReplacingMergeTree engine.",
+      "type": "integer",
+      "default": 1
+    }
+  },
+  "required": [
+    "series_gid",
+    "timestamp",
+    "metrics",
+    "signature"
+  ]
+}

--- a/schema/json-schema/defined_metric_schema.json
+++ b/schema/json-schema/defined_metric_schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/defined_metric_schema.json",
+  "title": "ContextSuite Defined Metric",
+  "description": "Schema for a metric definition within a time series.",
+  "type": "object",
+  "properties": {
+    "gid_url": {
+      "description": "RDF URL for the metric definition.",
+      "type": "string",
+      "format": "uri"
+    },
+    "gid": {
+      "description": "Unique GID for the metric definition.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "category": {
+      "description": "The category of the metric.",
+      "type": "string"
+    },
+    "label": {
+      "description": "The full human-readable name of the metric.",
+      "type": "string"
+    },
+    "slug": {
+      "description": "The slug of the metric, used as a key in metrics dictionaries.",
+      "type": "string"
+    },
+    "uom": {
+      "description": "The unit of measure for the metric. Should be a valid UOM code (e.g., from UN CEFACT list, like 'KGM' for kilogram).",
+      "type": "string"
+    },
+    "currency": {
+      "description": "The currency of the metric if applicable (e.g., USD).",
+      "type": ["null", "string"]
+    },
+    "adj_type": {
+      "description": "Adjustment type for the metric if it is a monetary value.",
+      "type": ["null", "string"],
+      "enum": [null, "NotAdjusted", "Adjusted", "Obfuscated", "Unknown"]
+    },
+    "adj_date": {
+      "description": "Date of adjustment if the monetary value is adjusted.",
+      "type": ["null", "string"],
+      "format": "date"
+    },
+    "wid": {
+      "description": "WikiData ID for what is being measured.",
+      "type": ["null", "string"]
+    },
+    "concept_id": {
+      "description": "Concept ID from a knowledge graph.",
+      "type": ["null", "string"]
+    },
+    "synset_id": {
+      "description": "Synset ID from a lexical database.",
+      "type": ["null", "string"]
+    },
+    "properties": {
+      "description": "Additional properties for the metric definition.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "agg": {
+      "description": "Default aggregation type for the metric.",
+      "type": ["null", "string"],
+      "enum": [null, "Sum", "Avg", "Min", "Max", "Custom"]
+    }
+  },
+  "required": [
+    "gid_url",
+    "gid",
+    "category",
+    "label",
+    "slug",
+    "uom"
+  ]
+}

--- a/schema/json-schema/embeddings_schema.json
+++ b/schema/json-schema/embeddings_schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/embeddings_schema.json",
+  "title": "ContextSuite Entity Embeddings",
+  "description": "Schema for an embedding associated with an entity's content.",
+  "type": "object",
+  "properties": {
+    "label": {
+      "description": "Label of the content that was embedded (e.g., 'Synopsis').",
+      "type": "string"
+    },
+    "model": {
+      "description": "The model used to generate the embedding (e.g., 'text-embedding-3-small').",
+      "type": "string"
+    },
+    "vectors": {
+      "description": "The vector representation.",
+      "type": "array",
+      "items": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "content_starts": {
+      "description": "Optional prefix to the content before embedding.",
+      "type": ["null", "string"]
+    },
+    "content_ends": {
+      "description": "Optional suffix to the content after embedding.",
+      "type": ["null", "string"]
+    },
+    "opening_phrase": {
+      "description": "Optional opening phrase used during embedding generation.",
+      "type": ["null", "string"]
+    },
+    "closing_phrase": {
+      "description": "Optional closing phrase used during embedding generation.",
+      "type": ["null", "string"]
+    }
+  },
+  "required": [
+    "label",
+    "model",
+    "vectors"
+  ]
+}

--- a/schema/json-schema/entity.json
+++ b/schema/json-schema/entity.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/entity.json",
+  "title": "ContextSuite Entity",
+  "description": "Schema for a ContextSuite Entity, based on SQL, Avro, and Pydantic models. SQL is the primary source of truth.",
+  "type": "object",
+  "properties": {
+    "gid": {
+      "description": "The Graph UUID of the entity",
+      "type": "string",
+      "format": "uuid"
+    },
+    "gid_url": {
+      "description": "The URL of the entity's GID",
+      "type": "string",
+      "format": "uri"
+    },
+    "label": {
+      "description": "The primary label of the entity (e.g. \"Eiffel Tower\")",
+      "type": "string"
+    },
+    "labels": {
+      "description": "Additional labels for the entity with language prefixes (e.g. [\"en:Eiffel Tower\", \"fr:Tour Eiffel\"])",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "type": {
+      "description": "The type of the entity (e.g. \"Event\", \"Place\", \"Person\"), always in English and in singular form and capitalized",
+      "type": "string"
+    },
+    "variant": {
+      "description": "The variant of the entity (e.g. \"Concert\", \"Exhibition\", \"Match\"), always in English and in singular form and capitalized",
+      "type": "string"
+    },
+    "icon": {
+      "description": "The icon of the entity (e.g. \"concert\", \"exhibition\", \"match\"), always in English and in singular form and capitalized",
+      "type": "string"
+    },
+    "colour": {
+      "description": "The colour of the entity (e.g. \"red\", \"blue\", \"green\"), always in English and in singular form and capitalized",
+      "type": "string"
+    },
+    "dimensions": {
+      "description": "Additional (generic) dimensions for the entity",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "description": "Additional tags for the entity",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "flags": {
+      "description": "Additional flags for the entity",
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "metrics": {
+      "description": "Additional metrics for the entity",
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "properties": {
+      "description": "Additional properties for the entity",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "names": {
+      "description": "Additional names for the entity, e.g. \"Eiffel Tower\" -> \"Tour Eiffel\"",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "content": {
+      "description": "List of content items related to the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "content_schema.json"
+      }
+    },
+    "media": {
+      "description": "List of media items associated with the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "media_schema.json"
+      }
+    },
+    "embeddings": {
+      "description": "List of embeddings for the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "embeddings_schema.json"
+      }
+    },
+    "ids": {
+      "description": "List of identifiers associated with the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "id_schema.json"
+      }
+    },
+    "classification": {
+      "description": "List of classifications for the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "classification_schema.json"
+      }
+    },
+    "location": {
+      "description": "List of locations associated with the entity.",
+      "type": "array",
+      "items": {
+        "$ref": "location_schema.json"
+      }
+    },
+    "partition": {
+      "description": "The storage partition for the entity. Internal use.",
+      "type": "string",
+      "default": "_open_"
+    },
+    "sign": {
+      "description": "Internal field for ReplacingMergeTree engine.",
+      "type": "integer",
+      "default": 1
+    }
+  },
+  "required": [
+    "gid",
+    "gid_url",
+    "label"
+  ]
+}

--- a/schema/json-schema/entity_linking_schema.json
+++ b/schema/json-schema/entity_linking_schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/entity_linking_schema.json",
+  "title": "ContextSuite Semantic Event Entity Linking",
+  "description": "Schema for an entity linking reference in a semantic event.",
+  "type": "object",
+  "properties": {
+    "content_key": {
+      "description": "Key of the content where the entity was found (e.g., 'body', 'subject').",
+      "type": "string"
+    },
+    "label": {
+      "description": "The textual mention of the entity in the content.",
+      "type": ["null", "string"]
+    },
+    "starts_at": {
+      "description": "The start index of the entity mention in the content.",
+      "type": ["null", "integer"]
+    },
+    "ends_at": {
+      "description": "The end index of the entity mention in the content.",
+      "type": ["null", "integer"]
+    },
+    "entity_type": {
+      "description": "The type of the linked entity (e.g., 'Person', 'Organization').",
+      "type": ["null", "string"]
+    },
+    "entity_gid": {
+      "description": "The Graph UUID of the linked entity.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "entity_wid": {
+      "description": "The Wikidata ID of the linked entity.",
+      "type": ["null", "string"]
+    },
+    "certainty": {
+      "description": "The certainty score of the entity linking.",
+      "type": ["null", "number"],
+      "format": "float"
+    }
+  },
+  "required": [
+    "content_key"
+  ]
+}

--- a/schema/json-schema/id_schema.json
+++ b/schema/json-schema/id_schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/id_schema.json",
+  "title": "ContextSuite Entity Identifier",
+  "description": "Schema for an identifier associated with an entity.",
+  "type": "object",
+  "properties": {
+    "label": {
+      "description": "Optional label for this identifier instance or the entity it points to.",
+      "type": ["null", "string"]
+    },
+    "role": {
+      "description": "Role of the identified entity in relation to the parent entity/event.",
+      "type": ["null", "string"]
+    },
+    "entity_type": {
+      "description": "Type of the entity being identified.",
+      "type": ["null", "string"]
+    },
+    "entity_gid": {
+      "description": "Graph UUID of the identified entity, if known.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "id": {
+      "description": "The actual identifier string.",
+      "type": ["null", "string"]
+    },
+    "id_type": {
+      "description": "The type or source of the identifier (e.g., ' বিক্রেতা ID', 'Customer ID').",
+      "type": ["null", "string"]
+    },
+    "capacity": {
+      "description": "Capacity related to this identifier's role or involvement.",
+      "type": ["null", "number"],
+      "format": "float"
+    }
+  }
+}

--- a/schema/json-schema/involved_schema.json
+++ b/schema/json-schema/involved_schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/involved_schema.json",
+  "title": "ContextSuite Semantic Event Involved Entity",
+  "description": "Schema for an entity involved in a semantic event.",
+  "type": "object",
+  "properties": {
+    "label": {
+      "description": "Optional label for this involvement instance or the entity it points to.",
+      "type": ["null", "string"]
+    },
+    "role": {
+      "description": "Role of the entity in the event (e.g., Supplier, Buyer).",
+      "type": "string"
+    },
+    "entity_type": {
+      "description": "Type of the entity involved (e.g., Person, Organization).",
+      "type": "string"
+    },
+    "entity_gid": {
+      "description": "Graph UUID of the involved entity, if known.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "id": {
+      "description": "The actual identifier string for the involved entity.",
+      "type": ["null", "string"]
+    },
+    "id_type": {
+      "description": "The type or source of the identifier (e.g., 'Zendesk ID', 'Stripe ID').",
+      "type": "string"
+    },
+    "capacity": {
+      "description": "Capacity of the entity in the event (e.g., fractional involvement).",
+      "type": ["null", "number"],
+      "format": "float"
+    }
+  },
+  "required": [
+    "role",
+    "entity_type",
+    "id_type"
+  ]
+}

--- a/schema/json-schema/library_schema.json
+++ b/schema/json-schema/library_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/library_schema.json",
+  "title": "ContextSuite Semantic Event Library",
+  "description": "Schema for event library information.",
+  "type": ["null", "object"],
+  "properties": {
+    "name": { "type": ["null", "string"], "description": "The name of the library (e.g. \"analytics-ios\")." },
+    "version": { "type": ["null", "string"], "description": "The version of the library (e.g. \"3.0.0\")." }
+  },
+  "additionalProperties": false
+}

--- a/schema/json-schema/location_schema.json
+++ b/schema/json-schema/location_schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/location_schema.json",
+  "title": "ContextSuite Location",
+  "description": "Schema for location information, usable for entities and events.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The type of the location (e.g. \"Home\", \"Work\", \"Venue\"). Used primarily for entity locations.",
+      "type": ["null", "string"]
+    },
+    "location_of": {
+      "description": "Describes what the location pertains to (e.g. \"Customer\", \"Supplier\"). Used primarily for event locations.",
+      "type": ["null", "string"]
+    },
+    "label": {
+      "description": "A readable label for the location",
+      "type": "string"
+    },
+    "country": { "type": ["null", "string"] },
+    "country_code": { "type": ["null", "string"] },
+    "code": { "type": ["null", "string"] },
+    "region": { "type": ["null", "string"] },
+    "division": { "type": ["null", "string"] },
+    "municipality": { "type": ["null", "string"] },
+    "locality": { "type": ["null", "string"] },
+    "postal_code": { "type": ["null", "string"] },
+    "postal_name": { "type": ["null", "string"] },
+    "street": { "type": ["null", "string"] },
+    "street_nr": { "type": ["null", "string"] },
+    "address": { "type": ["null", "string"] },
+    "longitude": { "type": ["null", "number"], "format": "double" },
+    "latitude": { "type": ["null", "number"], "format": "double" },
+    "geohash": { "type": ["null", "string"] },
+    "duration_from": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "duration_until": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "label"
+  ]
+}

--- a/schema/json-schema/media_schema.json
+++ b/schema/json-schema/media_schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/media_schema.json",
+  "title": "ContextSuite Entity Media",
+  "description": "Schema for a media item associated with an entity.",
+  "type": "object",
+  "properties": {
+    "media_type": {
+      "description": "Type of the media (e.g., Image, Video, Audio).",
+      "type": "string"
+    },
+    "type": {
+      "description": "Specific type of the media item (e.g., Poster, Thumbnail).",
+      "type": ["null", "string"]
+    },
+    "sub_type": {
+      "description": "Sub-type for further classification (e.g., Program, Season).",
+      "type": ["null", "string"]
+    },
+    "url": {
+      "description": "The URL of the media item.",
+      "type": "string",
+      "format": "uri"
+    },
+    "language": {
+      "description": "The primary language of the media.",
+      "type": ["null", "string"]
+    },
+    "aspect_ratio": {
+      "description": "The aspect ratio of the media (e.g., '16:9').",
+      "type": ["null", "string"]
+    }
+  },
+  "required": [
+    "media_type",
+    "url"
+  ]
+}

--- a/schema/json-schema/os_schema.json
+++ b/schema/json-schema/os_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/os_schema.json",
+  "title": "ContextSuite Semantic Event Operating System",
+  "description": "Schema for operating system information.",
+  "type": ["null", "object"],
+  "properties": {
+    "name": { "type": ["null", "string"], "description": "The name of the OS (e.g. \"iOS\")." },
+    "version": { "type": ["null", "string"], "description": "The version of the OS (e.g. \"9.1\")." }
+  },
+  "additionalProperties": false
+}

--- a/schema/json-schema/semantic_event.json
+++ b/schema/json-schema/semantic_event.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/semantic_event.json",
+  "title": "ContextSuite Semantic Event",
+  "description": "Schema for a ContextSuite Semantic Event. SQL is the primary source of truth.",
+  "type": "object",
+  "properties": {
+    "entity_gid": {
+      "description": "The entity that the event is associated with (Context Suite Specific)",
+      "type": "string",
+      "format": "uuid"
+    },
+    "timestamp": {
+      "description": "The timestamp of the event, always stored in UTC",
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "description": "The event type (e.g. \"track, page, identify, group, alias, screen etc.\")",
+      "type": ["null", "string"]
+    },
+    "event": {
+      "description": "The event name (e.g. \"Product Added\") always capitalized and always ended with a verb in passed tense",
+      "type": ["null", "string"]
+    },
+    "anonymous_id": { "type": ["null", "string"] },
+    "anonymous_gid": { "type": ["null", "string"], "format": "uuid" },
+    "user_id": { "type": ["null", "string"] },
+    "user_gid": { "type": ["null", "string"], "format": "uuid" },
+    "account_id": { "type": ["null", "string"] },
+    "previous_id": { "type": ["null", "string"] },
+    "session_id": { "type": ["null", "string"] },
+    "session_gid": { "type": ["null", "string"], "format": "uuid" },
+    "context_ip": { "type": ["null", "string"], "format": "ipv4" },
+    "importance": { "type": ["null", "integer"], "minimum": 1, "maximum": 5 },
+    "customer_facing": { "type": "integer", "default": 0 },
+    "content": {
+      "description": "A dictionary of additional content associated with the event",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "involves": {
+      "description": "Entities involved in the event",
+      "type": ["null", "array"],
+      "items": { "$ref": "involved_schema.json" }
+    },
+    "sentiment": {
+      "description": "Sentiment expressed in the event",
+      "type": ["null", "array"],
+      "items": { "$ref": "sentiment_schema.json" }
+    },
+    "classification": {
+      "description": "Classification of the event (Intent, Categories, etc.)",
+      "type": ["null", "array"],
+      "items": { "$ref": "classification_schema.json" }
+    },
+    "location": {
+      "description": "Location of the event",
+      "type": ["null", "array"],
+      "items": { "$ref": "location_schema.json" }
+    },
+    "entity_linking": {
+      "description": "Entity links from content to named entities",
+      "type": ["null", "array"],
+      "items": { "$ref": "entity_linking_schema.json" }
+    },
+    "contextual_awareness": {
+      "description": "Additional context for entities involved in the event",
+      "type": ["null", "array"],
+      "items": { "$ref": "contextual_awareness_schema.json" }
+    },
+    "properties": {
+      "description": "Additional properties for the event",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "dimensions": {
+      "description": "Additional low-cardinality dimensions for dashboards",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "metrics": {
+      "description": "Additional metrics for dashboards",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "number", "format": "float" }
+    },
+    "flags": {
+      "description": "Additional boolean flags",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "boolean" }
+    },
+    "campaign": { "$ref": "campaign_schema.json" },
+    "app": { "$ref": "app_schema.json" },
+    "device": { "$ref": "device_schema.json" },
+    "os": { "$ref": "os_schema.json" },
+    "library": { "$ref": "library_schema.json" },
+    "user_agent": { "$ref": "user_agent_schema.json" },
+    "network": { "$ref": "network_schema.json" },
+    "traits": { "$ref": "traits_schema.json" },
+    "page": { "$ref": "page_schema.json" },
+    "referrer": { "$ref": "referrer_schema.json" },
+    "screen": { "$ref": "screen_schema.json" },
+    "context": { "$ref": "context_schema.json" },
+    "commerce": { "$ref": "commerce_schema.json" },
+    "analysis": {
+      "description": "Cost analysis of the event (internal use)",
+      "type": ["null", "array"],
+      "items": { "$ref": "analysis_schema.json" }
+    },
+    "base_events": {
+      "description": "Base event information if this is a derived event",
+      "type": ["null", "array"],
+      "items": { "$ref": "base_event_info_schema.json" }
+    },
+    "access": {
+      "description": "Access control list for the event",
+      "type": ["null", "array"],
+      "items": { "$ref": "access_schema.json" }
+    },
+    "source": { "$ref": "source_info_schema.json" },
+    "local_time": { "type": ["null", "string"], "format": "date-time" },
+    "original_timestamp": { "type": ["null", "string"], "format": "date-time" },
+    "received_at": { "type": ["null", "string"], "format": "date-time" },
+    "sent_at": { "type": ["null", "string"], "format": "date-time" },
+    "message_id": { "type": "string" },
+    "event_gid": { "type": "string", "format": "uuid" },
+    "root_event_gid": { "type": "string", "format": "uuid" },
+    "analyse": {
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "boolean" }
+    },
+    "integrations": {
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "boolean" }
+    },
+    "write_key": { "type": "string" },
+    "ttl_days": { "type": ["null", "number"] },
+    "partition": { "type": "string" }
+  },
+  "required": [
+    "entity_gid",
+    "timestamp",
+    "type",
+    "event",
+    "message_id",
+    "event_gid",
+    "root_event_gid",
+    "write_key",
+    "partition"
+  ]
+}

--- a/schema/json-schema/sentiment_schema.json
+++ b/schema/json-schema/sentiment_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/sentiment_schema.json",
+  "title": "ContextSuite Semantic Event Sentiment",
+  "description": "Schema for sentiment expressed in a semantic event.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of the sentiment. SQL Enum8('Praise'=1, 'Criticism'=2, 'Complaint'=3, 'Abuse'=4, 'Threat'=5, 'Opinion'=6, 'Other'=0).",
+      "type": "string",
+      "enum": ["Praise", "Criticism", "Complaint", "Abuse", "Threat", "Opinion", "Other"]
+    },
+    "sentiment": {
+      "description": "The sentiment expressed.",
+      "type": "string"
+    },
+    "entity_type": {
+      "description": "The type of the entity that the sentiment is about.",
+      "type": ["null", "string"]
+    },
+    "entity_gid": {
+      "description": "The GID of the entity that the sentiment is expressed about.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "id_type": {
+      "description": "The ID type of the entity that the sentiment is expressed about.",
+      "type": ["null", "string"]
+    },
+    "id": {
+      "description": "The ID of the entity that the sentiment is expressed about.",
+      "type": ["null", "string"]
+    },
+    "target_category": {
+      "description": "The category of the target of the sentiment.",
+      "type": ["null", "string"]
+    },
+    "target_type": {
+      "description": "The type of the target of the sentiment.",
+      "type": ["null", "string"]
+    },
+    "target_entity": {
+      "description": "The specific target entity of the sentiment.",
+      "type": ["null", "string"]
+    },
+    "reason": {
+      "description": "The reasoning behind the sentiment.",
+      "type": ["null", "string"]
+    }
+  },
+  "required": [
+    "type",
+    "sentiment"
+  ]
+}

--- a/schema/json-schema/timeseries.json
+++ b/schema/json-schema/timeseries.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/timeseries.json",
+  "title": "ContextSuite Time Series",
+  "description": "Schema for a ContextSuite Time Series, including its metadata and references to data points.",
+  "type": "object",
+  "properties": {
+    "gid": {
+      "description": "Unique GID for the time series.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "gid_url": {
+      "description": "RDF URL for the time series.",
+      "type": "string",
+      "format": "uri"
+    },
+    "group_gid": {
+      "description": "Unique GID for the time series group.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "group_gid_url": {
+      "description": "RDF URL for the conceptual group this time series belongs to.",
+      "type": "string",
+      "format": "uri"
+    },
+    "label": {
+      "description": "Human-readable label for the time series.",
+      "type": "string"
+    },
+    "slug": {
+      "description": "URL-friendly slug generated from the label.",
+      "type": "string"
+    },
+    "value_types": {
+      "description": "The nature of the values in the time series (e.g., Actual, Forecast).",
+      "type": "string",
+      "enum": ["Actual", "Goal", "Estimation", "Projection", "Forecast", "Official", "Unknown"],
+      "default": "Actual"
+    },
+    "completeness": {
+      "description": "The completeness status of the time series data.",
+      "type": "string",
+      "enum": ["Unspecified", "Partial", "InProgress", "Complete", "Verified", "Golden", "Unknown", "Irrelevant"],
+      "default": "Complete"
+    },
+    "category": {
+      "description": "Primary category of the time series data.",
+      "type": ["null", "string"],
+      "enum": [null, "Agriculture", "Communication", "Culture", "Demography", "Economy", "Education", "Energy", "Environment", "Geography", "Governance", "Health", "Industry", "Infrastructure", "Media", "Other", "Philosophy", "Politics", "Physics", "Religion", "Science", "Security", "Society", "SocialMedia", "Sports", "Technology", "Tourism", "Transportation", "Weather"]
+    },
+    "sub_category": {
+      "description": "Sub-category providing more specific classification.",
+      "type": ["null", "string"]
+    },
+    "resolution": {
+      "description": "The resolution or frequency of data points (e.g., P1D for daily, PT1H for hourly).",
+      "type": ["null", "string"],
+      "enum": [null, "PNT", "P1Y", "P1Q", "P2M", "P1M", "P2W", "P1W", "P1D", "PT1H", "PT30M", "PT15M", "PT10M", "PT5M", "PTM", "PT1S"]
+    },
+    "metrics": {
+      "description": "Dictionary of defined metrics included in this time series, keyed by metric slug.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "defined_metric_schema.json"
+      }
+    },
+    "owner_gid": {
+      "description": "The GID of the entity that owns this time series data.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "source_gid": {
+      "description": "The GID of the entity that is the source of this time series data.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "publisher_gid": {
+      "description": "The GID of the entity that published this time series data.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "publication_gid": {
+      "description": "The GID of the specific publication this time series belongs to, if any.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "dimensions": {
+      "description": "Additional (generic) dimensions for the time series.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "tags": {
+      "description": "Additional tags for the time series.",
+      "type": ["null", "array"],
+      "items": { "type": "string" }
+    },
+    "flags": {
+      "description": "Additional boolean flags for the time series.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "boolean" }
+    },
+    "metric_gid": {
+        "description": "Map of metric slugs to their GIDs, if they are also managed as separate entities.",
+        "type": ["null", "object"],
+        "additionalProperties": {"type": "string", "format": "uuid"}
+    },
+    "properties": {
+      "description": "Additional properties for the time series.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    },
+    "access": {
+      "description": "Access type for the time series.",
+      "type": "string",
+      "enum": ["Local", "Exclusive", "Group", "SharedPercentiles", "SharedObfuscated", "Shared", "Public"],
+      "default": "Public"
+    },
+    "uom": {
+        "description": "Primary or default unit of measure for the entire series, if applicable.",
+        "type": ["null", "string"]
+    },
+    "datapoints": {
+      "description": "The data points of the time series. Actual data points will be defined in data_point.json, this is a placeholder if we embed.",
+      "type": "array",
+      "items": {
+        "$ref": "data_point.json"
+      }
+    }
+  },
+  "required": [
+    "gid",
+    "gid_url",
+    "group_gid",
+    "group_gid_url",
+    "label",
+    "slug",
+    "metrics",
+    "source_gid"
+  ]
+}

--- a/schema/json-schema/uom.json
+++ b/schema/json-schema/uom.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextsuite.com/schemas/uom.json",
+  "title": "ContextSuite Unit of Measure (UOM)",
+  "description": "Schema for a Unit of Measure (UOM) entity.",
+  "type": "object",
+  "properties": {
+    "code": {
+      "description": "CEFACT code for the unit of measure (e.g., 'kg', 'm', 's').",
+      "type": "string"
+    },
+    "label": {
+      "description": "Human-readable label for the UOM (e.g., 'Kilogram', 'Meter').",
+      "type": "string"
+    },
+    "symbol": {
+      "description": "Symbol for the UOM (e.g., 'kg', 'm').",
+      "type": "string"
+    },
+    "slug": {
+      "description": "URL-friendly version of the code (e.g., 'kilogram', 'meter').",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the UOM.",
+      "type": ["null", "string"]
+    },
+    "conversion": {
+      "description": "Conversion factor to a base unit.",
+      "type": ["null", "string"]
+    },
+    "core_unit": {
+      "description": "Core unit this UOM is based on (e.g., 'kg' for mass).",
+      "type": ["null", "string"]
+    },
+    "level": {
+      "description": "Level in a hierarchy (e.g., 'base', 'derived').",
+      "type": ["null", "string"]
+    },
+    "sectors": {
+      "description": "Sectors where this UOM is applicable.",
+      "type": ["null", "array"],
+      "items": { "type": "string" }
+    },
+    "quantities": {
+      "description": "Quantities this UOM can measure.",
+      "type": ["null", "array"],
+      "items": { "type": "string" }
+    },
+    "schema_name": {
+      "description": "Schema or standard this UOM adheres to (e.g., 'SI', 'Imperial'). Renamed from 'schema' to avoid conflict.",
+      "type": ["null", "string"]
+    },
+    "properties": {
+      "description": "Additional properties for the UOM.",
+      "type": ["null", "object"],
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "required": [
+    "code",
+    "label",
+    "symbol",
+    "slug"
+  ]
+}


### PR DESCRIPTION
This commit adds more JSON schemas for nested objects, primarily those referenced by the `semantic_event.json` schema. My approach has been to define these based on their Avro, Pydantic, and SQL definitions, prioritizing SQL as the source of truth and ensuring flexibility by making most fields within these sub-schemas optional/nullable.

Key changes and progress since the last commit:

1.  **Schemas for Entity Nested Objects (Completed):**
    *   `media_schema.json`: For media items linked to entities.
    *   `embeddings_schema.json`: For embedding information.

2.  **Schema for TimeSeries Nested Objects (Completed):**
    *   `defined_metric_schema.json`: For definitions of metrics within a time series.

3.  **Schemas for Semantic Event Nested Objects (In Progress):**
    *   `involved_schema.json`: For entities involved in an event.
    *   `sentiment_schema.json`: For sentiment details expressed in an event.
    *   `entity_linking_schema.json`: For links between content and named entities.
    *   `contextual_awareness_schema.json`: For additional context about entities in an event.
    *   Batch 1 of simpler event attribute schemas:
        *   `campaign_schema.json`
        *   `app_schema.json`
        *   `os_schema.json`
        *   `library_schema.json`

The process involves:
- Examining the Avro schema for the object.
- Consulting the corresponding Pydantic model (if available).
- Checking the SQL definition (especially for `Nested` types and nullability).
- Creating a new `.json` schema file in `schema/json-schema/`.
- Making fields optional/nullable (`["null", "type"]`) and objects themselves potentially null (`type: ["null", "object"]`) to align with Pydantic `OmitIfNone` and SQL `LowCardinality(String)` or `Nullable()` where appropriate.
- Setting `additionalProperties: false` for these sub-schemas.

I have paused before creating the next batch of schemas for semantic event properties (`network_schema.json`, `page_schema.json`, `referrer_schema.json`, `screen_schema.json`). You have approved continuing with this approach. The next steps would be to generate these, followed by more complex nested schemas like `user_agent`, `device`, `traits`, `context`, and `commerce` (which includes `product`). Ensuring all `$ref`s resolve correctly by creating all referenced schemas remains a key task for subsequent work.