### PR TITLE
Enrich JSON schema descriptions from SQL comments

### DIFF
--- a/schema/json-schema/access_schema.json
+++ b/schema/json-schema/access_schema.json
@@ -8,9 +8,9 @@
     "type": { "type": ["null", "string"], "enum": [null, "Blacklisted", "Whitelisted"], "description": "Type of access rule." },
     "label": { "type": ["null", "string"], "description": "Label for the access rule or the user/group it applies to." },
     "user_gid": { "type": ["null", "string"], "format": "uuid", "description": "User GID this rule applies to." },
-    "organization_gid": { "type": ["null", "string"], "format": "uuid", "description": "Organization GID this rule applies to." },
-    "date_from": { "type": ["null", "string"], "format": "date-time", "description": "Timestamp from which this access rule is effective." },
-    "date_to": { "type": ["null", "string"], "format": "date-time", "description": "Timestamp until which this access rule is effective." }
+    "organization_gid": { "type": ["null", "string"], "format": "uuid", "description": "Organization GID this rule applies to, potentially representing a department or sub-organization." },
+    "date_from": { "type": ["null", "string"], "format": "date-time", "description": "Timestamp from which this access rule is effective (access start date)." },
+    "date_to": { "type": ["null", "string"], "format": "date-time", "description": "Timestamp until which this access rule is effective (access end date)." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/base_event_info_schema.json
+++ b/schema/json-schema/base_event_info_schema.json
@@ -6,9 +6,9 @@
   "type": ["null", "object"],
   "properties": {
     "event_gid": { "type": ["null", "string"], "format": "uuid", "description": "The GID of the original root event." },
-    "type": { "type": ["null", "string"], "description": "The type of the original root event." },
-    "event": { "type": ["null", "string"], "description": "The name of the original root event." },
-    "timestamp": { "type": ["null", "string"], "format": "date-time", "description": "The timestamp of the original root event." },
+    "type": { "type": ["null", "string"], "description": "The type of the original root event (e.g., 'page', 'track', 'identify', 'group', 'alias', 'screen', 'commerce')." },
+    "event": { "type": ["null", "string"], "description": "The name of the original root event (e.g., 'Page Viewed', 'Product Added', 'User Signed Up')." },
+    "timestamp": { "type": ["null", "string"], "format": "date-time", "description": "The timestamp of the original root event in UTC (e.g., '2022-01-01T00:00:00Z')." },
     "message_id": { "type": ["null", "string"], "description": "The message ID of the original root event." },
     "entity_gid": { "type": ["null", "string"], "format": "uuid", "description": "The entity GID associated with the original root event." }
   },

--- a/schema/json-schema/classification_schema.json
+++ b/schema/json-schema/classification_schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "type": {
-      "description": "The type of classification (e.g., 'Intent', 'Category', 'Tag'). For entities, this might be 'event category->subcategory'.",
+      "description": "The type of classification. For semantic events, this can be 'Intent', 'Intent Category', 'Category', 'Subcategory', 'Tag', 'Segmentation', 'Age Group', 'Inbox', 'Keyword', 'Priority', 'Other', often mapped from an internal Enum. For entities, an example is 'event category->subcategory'.",
       "type": "string"
     },
     "value": {
@@ -14,7 +14,7 @@
       "type": "string"
     },
     "babelnet_id": {
-      "description": "BabelNet ID for the classification concept (primarily for entities).",
+      "description": "BabelNet ID for the classification concept, used to translate and associate the classification with other systems (primarily for entities).",
       "type": ["null", "string"]
     },
     "reasoning": {

--- a/schema/json-schema/commerce_schema.json
+++ b/schema/json-schema/commerce_schema.json
@@ -5,31 +5,114 @@
   "description": "Schema for commerce-related information in a semantic event.",
   "type": ["null", "object"],
   "properties": {
-    "details": { "type": ["null", "string"] },
-    "checkout_id": { "type": ["null", "string"] },
-    "order_id": { "type": ["null", "string"] },
-    "cart_id": { "type": ["null", "string"] },
-    "employee_id": { "type": ["null", "string"] },
-    "external_order_id": { "type": ["null", "string"] },
-    "terminal_id": { "type": ["null", "string"] },
-    "affiliation_id": { "type": ["null", "string"] },
-    "affiliation": { "type": ["null", "string"] },
-    "agent": { "type": ["null", "string"] },
-    "agent_id": { "type": ["null", "string"] },
-    "sold_location": { "type": ["null", "string"] },
-    "sold_location_id": { "type": ["null", "string"] },
-    "business_day": { "type": ["null", "string"], "format": "date" },
-    "revenue": { "type": ["null", "number"], "format": "double" },
-    "tax": { "type": ["null", "number"], "format": "double" },
-    "discount": { "type": ["null", "number"], "format": "double" },
-    "cogs": { "type": ["null", "number"], "format": "double" },
-    "commission": { "type": ["null", "number"], "format": "double" },
-    "currency": { "type": ["null", "string"] },
-    "exchange_rate": { "type": ["null", "number"], "format": "float", "default": 1.0 },
-    "coupon": { "type": ["null", "string"] },
-    "payment_type": { "type": ["null", "string"] },
-    "payment_sub_type": { "type": ["null", "string"] },
-    "payment_details": { "type": ["null", "string"] },
+    "details": {
+      "description": "Other properties of the commerce event that cannot be mapped to the schema or have complex data types.",
+      "type": ["null", "string"]
+    },
+    "checkout_id": {
+      "description": "Unique ID for the checkout.",
+      "type": ["null", "string"]
+    },
+    "order_id": {
+      "description": "Unique ID for the order.",
+      "type": ["null", "string"]
+    },
+    "cart_id": {
+      "description": "Unique ID for the cart.",
+      "type": ["null", "string"]
+    },
+    "employee_id": {
+      "description": "Unique ID for the employee working the terminal/register.",
+      "type": ["null", "string"]
+    },
+    "external_order_id": {
+      "description": "Unique External ID for the order.",
+      "type": ["null", "string"]
+    },
+    "terminal_id": {
+      "description": "Unique External ID for the terminal used for the transaction.",
+      "type": ["null", "string"]
+    },
+    "affiliation_id": {
+      "description": "Unique ID for the affiliation.",
+      "type": ["null", "string"]
+    },
+    "affiliation": {
+      "description": "Store or affiliation from which this transaction occurred (e.g., Google Store).",
+      "type": ["null", "string"]
+    },
+    "agent": {
+      "description": "The Agent responsible for the sale.",
+      "type": ["null", "string"]
+    },
+    "agent_id": {
+      "description": "The ID of the Agent responsible for the sale.",
+      "type": ["null", "string"]
+    },
+    "sold_location": {
+      "description": "The location where the sale occurred.",
+      "type": ["null", "string"]
+    },
+    "sold_location_id": {
+      "description": "The ID of the location where the sale occurred.",
+      "type": ["null", "string"]
+    },
+    "business_day": {
+      "description": "The business day of the transaction.",
+      "type": ["null", "string"],
+      "format": "date"
+    },
+    "revenue": {
+      "description": "Total gross revenue for the transaction. Note: Segment's spec often uses 'total' for this concept if 'revenue' might only include product revenue; check specific event for usage.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "tax": {
+      "description": "Total tax amount for the transaction.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "discount": {
+      "description": "Total discount amount for the transaction.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "cogs": {
+      "description": "Total cost of goods sold for the transaction.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "commission": {
+      "description": "Total commission amount for the transaction.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "currency": {
+      "description": "Currency code associated with the transaction (e.g., 'USD').",
+      "type": ["null", "string"]
+    },
+    "exchange_rate": {
+      "description": "Currency exchange rate associated with the transaction.",
+      "type": ["null", "number"],
+      "format": "float",
+      "default": 1.0
+    },
+    "coupon": {
+      "description": "Transaction coupon redeemed with the transaction (e.g., 'SUMMER20').",
+      "type": ["null", "string"]
+    },
+    "payment_type": {
+      "description": "Type of payment (e.g., 'Card', 'Paypal', 'Cash').",
+      "type": ["null", "string"]
+    },
+    "payment_sub_type": {
+      "description": "Subtype of payment (e.g., 'Visa', 'Mastercard').",
+      "type": ["null", "string"]
+    },
+    "payment_details": {
+      "description": "Details of the payment (e.g., last 4 digits of a credit card).",
+      "type": ["null", "string"]
+    },
     "products": {
       "type": ["null", "array"],
       "items": { "$ref": "product_schema.json" }

--- a/schema/json-schema/content_schema.json
+++ b/schema/json-schema/content_schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "label": {
-      "description": "The label of the content (e.g. \"Prologue\", \"Synopsis\")",
+      "description": "The label of the content (e.g., 'Prologue', 'Synopsis', 'Description', 'Summary', 'Conditions', 'History', 'Other').",
       "type": "string"
     },
     "type": {
@@ -26,7 +26,7 @@
       "type": ["null", "string"]
     },
     "meta_description": {
-      "description": "A description of the content's purpose.",
+      "description": "A description of the content's purpose and potentially a few questions it may answer.",
       "type": ["null", "string"]
     }
   },

--- a/schema/json-schema/context_schema.json
+++ b/schema/json-schema/context_schema.json
@@ -5,24 +5,24 @@
   "description": "Schema for general context information of a semantic event.",
   "type": ["null", "object"],
   "properties": {
-    "active": { "type": ["null", "boolean"], "description": "Whether the library/client is active." },
+    "active": { "type": ["null", "boolean"], "description": "Whether the library/client is active (e.g., true, often represented as 1 in source data)." },
     "ip": { "type": ["null", "string"], "format": "ipv4", "description": "IPv4 address of the client." },
     "ipv6": { "type": ["null", "string"], "format": "ipv6", "description": "IPv6 address of the client." },
-    "locale": { "type": ["null", "string"], "description": "Locale string of the client (e.g., 'en-US')." },
-    "group_id": { "type": ["null", "string"], "description": "Identifier for a group the user belongs to." },
-    "timezone": { "type": ["null", "string"], "description": "Timezone of the client (e.g., 'America/Los_Angeles')." },
+    "locale": { "type": ["null", "string"], "description": "The locale string used where the event happened (e.g., 'en-US')." },
+    "group_id": { "type": ["null", "string"], "description": "The group ID associated with the event, if any (e.g., 'a89d88da-4f4b-11e5-9e98-2f3c942e34c8')." },
+    "timezone": { "type": ["null", "string"], "description": "The timezone in which the event happened (e.g., 'America/Los_Angeles')." },
     "location": {
       "type": ["null", "array"],
       "items": { "type": "number", "format": "double" },
       "minItems": 2,
       "maxItems": 2,
-      "description": "Geographic location as [longitude, latitude]."
+      "description": "Geographic location associated with the event, typically as [longitude, latitude] (e.g., [-122.5776844, 37.7576171]). Note: SQL source might use a Point type."
     },
     "region": { "type": ["null", "string"], "description": "Deployment region or similar (e.g., 'AWS-West')." },
     "namespace": { "type": ["null", "string"], "description": "Kubernetes namespace where the event originated." },
     "hostname": { "type": ["null", "string"], "description": "Hostname of the server where the event originated." },
     "pod": { "type": ["null", "string"], "description": "Kubernetes pod name where the event originated." },
-    "extras": { "type": ["null", "string"], "description": "JSON string or stringified object for any other context properties not fitting standard fields." }
+    "extras": { "type": ["null", "string"], "description": "Other context properties of the event that cannot be mapped to standard fields or have complex data types. Often a JSON string or stringified object." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/contextual_awareness_schema.json
+++ b/schema/json-schema/contextual_awareness_schema.json
@@ -6,24 +6,24 @@
   "type": "object",
   "properties": {
     "type": {
-      "description": "Type of contextual information (e.g., Description, Summary, Conditions).",
+      "description": "Type of contextual information (e.g., 'Description', 'Summary', 'Conditions', 'History', 'Other').",
       "type": "string"
     },
     "entity_type": {
-      "description": "The type of the entity this context refers to (e.g., 'Currency', 'Product').",
+      "description": "The type of the entity this context refers to (e.g., 'Currency', 'Product', 'Service', 'Other').",
       "type": "string"
     },
     "entity_gid": {
-      "description": "The Graph UUID of the entity this context refers to.",
+      "description": "The Graph UUID of the entity this context refers to. This is a Context Suite specific GID, potentially an Account or any sub-entity.",
       "type": ["null", "string"],
       "format": "uuid"
     },
     "entity_wid": {
-      "description": "The Wikidata ID of the entity this context refers to.",
+      "description": "The Wikidata ID (WID) of the entity this context refers to. This is a Context Suite specific WID, potentially an Account or any sub-entity.",
       "type": ["null", "string"]
     },
     "context": {
-      "description": "The actual contextual information string.",
+      "description": "The actual contextual information string (e.g., 'Silfra is an extremely cold pond with a constant temperature of 2° celsius').",
       "type": ["null", "string"]
     }
   },

--- a/schema/json-schema/data_point.json
+++ b/schema/json-schema/data_point.json
@@ -21,11 +21,11 @@
       "format": "uri"
     },
     "geohash": {
-      "description": "Geolocation as a geohash.",
+      "description": "Geolocation as a geohash (for clustering and sorting) - moves for non-stationary entities",
       "type": ["null", "string"]
     },
     "period": {
-      "description": "The resolution/frequency of the data (e.g., 'PT1H', 'P1D').",
+      "description": "The resolution/frequency of the data in ISO 8601 duration format (e.g., 'PT1H' for hourly, 'P1D' for daily, 'P1M' for monthly, etc.).",
       "type": ["null", "string"]
     },
     "timestamp": {
@@ -33,10 +33,26 @@
       "type": "string",
       "format": "date-time"
     },
-    "owner_gid": { "type": ["null", "string"], "format": "uuid" },
-    "source_gid": { "type": ["null", "string"], "format": "uuid" },
-    "publisher_gid": { "type": ["null", "string"], "format": "uuid" },
-    "publication_gid": { "type": ["null", "string"], "format": "uuid" },
+    "owner_gid": {
+      "description": "The GID of the owner that this data point belongs to. Links to an Entity.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "source_gid": {
+      "description": "The GID of the source that this data point belongs to. Links to an Entity.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "publisher_gid": {
+      "description": "The GID of the publisher that this data point belongs to. Links to an Entity.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "publication_gid": {
+      "description": "The GID of the publication that this data point belongs to. Links to an Entity.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
     "gids": {
       "description": "Additional links to Named Entities.",
       "type": ["null", "object"],
@@ -103,22 +119,22 @@
       "additionalProperties": { "type": "string" }
     },
     "uom": {
-      "description": "Unit of measure for the metrics.",
+      "description": "Unit of measure for the metrics. All UOM are linked to a UOM Entity.",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     },
     "of_what": {
-      "description": "What the metric is measuring (e.g., 'population').",
+      "description": "What the metric is measuring, often based on a standard (e.g., from Wikidata/DBPedia). The key is the metric name and the value is the standard (e.g., 'population', 'oil', 'humidity', etc.).",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     },
     "agg_method": {
-      "description": "Default aggregation method for the metric.",
+      "description": "The default aggregation method for the metric. The key is the metric name and the value is the aggregation method (e.g., 'sum', 'avg', 'max', 'min', etc.).",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     },
     "access_type": {
-      "description": "Access type for the data point.",
+      "description": "Access type for the data point, derived from an Enum in the source database defining levels like Local, Exclusive, Group, Shared, Public etc.",
       "type": ["null", "string"],
       "enum": [null, "Local", "Exclusive", "Group", "SharedPercentiles", "SharedObfuscated", "Shared", "Public"],
       "default": "Exclusive"
@@ -129,7 +145,7 @@
       "format": "uuid"
     },
     "partition": {
-      "description": "Partition key for the data point.",
+      "description": "The version of the event message, used for partitioning.",
       "type": ["null", "string"]
     },
     "sign": {

--- a/schema/json-schema/device_schema.json
+++ b/schema/json-schema/device_schema.json
@@ -5,20 +5,20 @@
   "description": "Schema for device information related to a semantic event.",
   "type": ["null", "object"],
   "properties": {
-    "ad_tracking_enabled": { "type": ["null", "boolean"], "description": "Whether ad tracking is enabled." },
-    "id": { "type": ["null", "string"], "description": "Device identifier (e.g., manufacturer ID)." },
-    "version": { "type": ["null", "string"], "description": "Version of the device model or OS." },
-    "mac_address": { "type": ["null", "string"], "description": "Device MAC address." },
+    "ad_tracking_enabled": { "type": ["null", "boolean"], "description": "Whether ad tracking is enabled (e.g., true)." },
+    "id": { "type": ["null", "string"], "description": "The manufacturer ID for the device (e.g., 'e3bcf3f796b9f377284bfbfbcf1f8f92b6')." },
+    "version": { "type": ["null", "string"], "description": "The device version (e.g., '9.1')." },
+    "mac_address": { "type": ["null", "string"], "description": "The device MAC address (e.g., '00:00:00:00:00:00')." },
     "manufacturer": { "type": ["null", "string"], "description": "Device manufacturer (e.g., 'Apple')." },
     "model": { "type": ["null", "string"], "description": "Device model (e.g., 'iPhone 6')." },
     "name": { "type": ["null", "string"], "description": "Device name (e.g., 'Nexus 5')." },
-    "type": { "type": ["null", "string"], "description": "Type of device (e.g., 'Mobile', 'Tablet')." },
-    "token": { "type": ["null", "string"], "description": "Device token for push notifications, etc." },
+    "type": { "type": ["null", "string"], "description": "The type of the device (e.g., 'Mobile', 'Tablet', 'Desktop', 'TV', 'Wearable', 'Other')." },
+    "token": { "type": ["null", "string"], "description": "Device token, often used for push notifications (e.g., 'e3bcf3f796b9f377284bfbfbcf1f8f92b6')." },
     "locale": { "type": ["null", "string"], "description": "Locale of the device (e.g., 'en-US')." },
     "timezone": { "type": ["null", "string"], "description": "Timezone of the device (e.g., 'America/Los_Angeles')." },
     "brand": { "type": ["null", "string"], "description": "Device brand (often same as manufacturer)." },
     "variant": { "type": ["null", "string"], "description": "Device variant (e.g., 'iPhone 6s')." },
-    "advertising_id": { "type": ["null", "string"], "description": "Advertising ID of the device." }
+    "advertising_id": { "type": ["null", "string"], "description": "The advertising ID of the device (e.g., '350e9d90-d7f5-11e4-b9d6-1681e6b88ec1')." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/embeddings_schema.json
+++ b/schema/json-schema/embeddings_schema.json
@@ -6,15 +6,15 @@
   "type": "object",
   "properties": {
     "label": {
-      "description": "Label of the content that was embedded (e.g., 'Synopsis').",
+      "description": "Label of the content that was embedded, typically matching a label from the entity's content array (e.g., 'Prologue', 'Synopsis', 'Description', 'Summary', 'Conditions', 'History', 'Other').",
       "type": "string"
     },
     "model": {
-      "description": "The model used to generate the embedding (e.g., 'text-embedding-3-small').",
+      "description": "The model used to generate the embedding (e.g., 'text-embedding-3-small', 'text-embedding-3-large').",
       "type": "string"
     },
     "vectors": {
-      "description": "The vector representation.",
+      "description": "The vector representation of the content, used for similarity search and clustering (e.g., an array of floats, often 1024 dimensions).",
       "type": "array",
       "items": {
         "type": "number",
@@ -22,19 +22,19 @@
       }
     },
     "content_starts": {
-      "description": "Optional prefix to the content before embedding.",
+      "description": "Optional prefix added to the content before embedding (e.g., 'Title: ', 'Description: ', 'Content: ').",
       "type": ["null", "string"]
     },
     "content_ends": {
-      "description": "Optional suffix to the content after embedding.",
+      "description": "Optional suffix added to the content after embedding (e.g., ' ', '.', ' - ').",
       "type": ["null", "string"]
     },
     "opening_phrase": {
-      "description": "Optional opening phrase used during embedding generation.",
+      "description": "Optional opening phrase used during the generation of the embedding input (e.g., 'This is a description of ', 'This is a content of ').",
       "type": ["null", "string"]
     },
     "closing_phrase": {
-      "description": "Optional closing phrase used during embedding generation.",
+      "description": "Optional closing phrase used during the generation of the embedding input (e.g., ' for more information.', ' for more details.').",
       "type": ["null", "string"]
     }
   },

--- a/schema/json-schema/entity.json
+++ b/schema/json-schema/entity.json
@@ -127,12 +127,12 @@
       }
     },
     "partition": {
-      "description": "The storage partition key for the entity. Primarily for internal database use.",
+      "description": "The storage partition for the entity. This is internal and cannot be submitted by the user. It is used to partition the data for performance and scalability.",
       "type": "string",
       "default": "_open_"
     },
     "sign": {
-      "description": "Internal field for ClickHouse ReplacingMergeTree engine to handle updates and deletions. Should typically be 1 for active records.",
+      "description": "Internal field for ReplacingMergeTree, used to mark the latest version of the entity and ensure correct updates/replacements.",
       "type": "integer",
       "default": 1
     }

--- a/schema/json-schema/entity_linking_schema.json
+++ b/schema/json-schema/entity_linking_schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "content_key": {
-      "description": "Key of the content where the entity was found (e.g., 'body', 'subject').",
+      "description": "Key of the content text where the entity was found (e.g., 'body', 'subject', 'title', 'description', 'summary', 'quick response', 'other').",
       "type": "string"
     },
     "label": {
@@ -22,7 +22,7 @@
       "type": ["null", "integer"]
     },
     "entity_type": {
-      "description": "The type of the linked entity (e.g., 'Person', 'Organization').",
+      "description": "The type of the linked entity (e.g., 'Person', 'Organization', 'LegalEntity').",
       "type": ["null", "string"]
     },
     "entity_gid": {

--- a/schema/json-schema/involved_schema.json
+++ b/schema/json-schema/involved_schema.json
@@ -10,15 +10,15 @@
       "type": ["null", "string"]
     },
     "role": {
-      "description": "Role of the entity in the event (e.g., Supplier, Buyer).",
+      "description": "Role of the entity in the event (e.g., 'Supplier', 'Buyer', 'Victim', 'HomeTeam'). Should be capitalized.",
       "type": "string"
     },
     "entity_type": {
-      "description": "Type of the entity involved (e.g., Person, Organization).",
+      "description": "Type of the entity involved (e.g., 'Person', 'Organization', 'LegalEntity'). Should be a capitalized entity name.",
       "type": "string"
     },
     "entity_gid": {
-      "description": "Graph UUID of the involved entity, if known.",
+      "description": "The Graph UUID (GID) of the involved entity, if known. Entity GIDs are ContextSuite native identifiers. Use the 'id' field for other types of identifiers.",
       "type": ["null", "string"],
       "format": "uuid"
     },
@@ -27,11 +27,11 @@
       "type": ["null", "string"]
     },
     "id_type": {
-      "description": "The type or source of the identifier (e.g., 'Zendesk ID', 'Stripe ID').",
+      "description": "Indicates the type or source of the 'id' (e.g., 'Zendesk ID', 'Stripe ID', or your own organization's name if the ID is internal).",
       "type": "string"
     },
     "capacity": {
-      "description": "Capacity of the entity in the event (e.g., fractional involvement).",
+      "description": "The capacity or extent of the entity's involvement in the event. If fractional, this represents the fraction (e.g., 0.5 for half involvement of a person).",
       "type": ["null", "number"],
       "format": "float"
     }

--- a/schema/json-schema/location_schema.json
+++ b/schema/json-schema/location_schema.json
@@ -6,37 +6,86 @@
   "type": "object",
   "properties": {
     "type": {
-      "description": "The type of the location (e.g. \"Home\", \"Work\", \"Venue\"). Used primarily for entity locations.",
+      "description": "The type of the location (e.g., 'Home', 'Work', 'Venue', 'Address', 'Geographic', 'Permanent', 'Temporary', 'Other'). Used primarily for entity locations.",
       "type": ["null", "string"]
     },
     "location_of": {
-      "description": "Describes what the location pertains to (e.g. \"Customer\", \"Supplier\"). Used primarily for event locations.",
+      "description": "Describes what the location pertains to (e.g., 'Customer', 'Supplier', 'Postal Address', 'Business Address', 'Home Address', 'Other'). Used primarily for event locations.",
       "type": ["null", "string"]
     },
     "label": {
-      "description": "A readable label for the location",
+      "description": "A readable label for the location (e.g., 'Street name 1, 1234').",
       "type": "string"
     },
-    "country": { "type": ["null", "string"] },
-    "country_code": { "type": ["null", "string"] },
-    "code": { "type": ["null", "string"] },
-    "region": { "type": ["null", "string"] },
-    "division": { "type": ["null", "string"] },
-    "municipality": { "type": ["null", "string"] },
-    "locality": { "type": ["null", "string"] },
-    "postal_code": { "type": ["null", "string"] },
-    "postal_name": { "type": ["null", "string"] },
-    "street": { "type": ["null", "string"] },
-    "street_nr": { "type": ["null", "string"] },
-    "address": { "type": ["null", "string"] },
-    "longitude": { "type": ["null", "number"], "format": "double" },
-    "latitude": { "type": ["null", "number"], "format": "double" },
-    "geohash": { "type": ["null", "string"] },
+    "country": {
+      "description": "The country of the location (e.g., 'France', 'United States', 'Germany'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "country_code": {
+      "description": "The 3-letter country code of the location (e.g., 'FRA', 'USA', 'DEU'). Should be in uppercase.",
+      "type": ["null", "string"]
+    },
+    "code": {
+      "description": "A code for the location, which could be a postal code or other area identifier (e.g., '75001', '10001', '10115'). Should be in uppercase. Note: `postal_code` is a separate field if specifically a postal code.",
+      "type": ["null", "string"]
+    },
+    "region": {
+      "description": "The region of the location (e.g., 'Île-de-France', 'New York', 'Berlin'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "division": {
+      "description": "The division of the location (e.g., 'Paris', 'Manhattan', 'Mitte'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "municipality": {
+      "description": "The municipality of the location (e.g., 'Paris', 'New York', 'Berlin'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "locality": {
+      "description": "The locality or neighbourhood of the location (e.g., 'Montmartre', 'SoHo', 'Kreuzberg'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "postal_code": {
+      "description": "The postal code of the location (e.g., '75001', '10001', '10115'). Should be in uppercase.",
+      "type": ["null", "string"]
+    },
+    "postal_name": {
+      "description": "The name of the postal code area (e.g., '1er Arrondissement', 'Chelsea', 'Mitte'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "street": {
+      "description": "The street of the location (e.g., 'Rue de Rivoli', 'Broadway', 'Friedrichstraße'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "street_nr": {
+      "description": "The street number of the location (e.g., '1', '100', '15'). Should be in uppercase.",
+      "type": ["null", "string"]
+    },
+    "address": {
+      "description": "The full address of the location (e.g., '1 Rue de Rivoli, 75001 Paris, France'). Should be in English, singular form, and capitalized.",
+      "type": ["null", "string"]
+    },
+    "longitude": {
+      "description": "The longitude of the location (e.g., 2.3364, -74.0060, 13.3889).",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "latitude": {
+      "description": "The latitude of the location (e.g., 48.8606, 40.7128, 52.5166).",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "geohash": {
+      "description": "The geohash of the location (e.g., 'u09t2', 'dqcjq', 's9z6x'). Should be in lowercase.",
+      "type": ["null", "string"]
+    },
     "duration_from": {
+      "description": "The start date/timestamp from which the location is valid (e.g., '2023-01-01T00:00:00Z'). Used if the location is temporary.",
       "type": ["null", "string"],
       "format": "date-time"
     },
     "duration_until": {
+      "description": "The end date/timestamp until which the location is valid (e.g., '2023-12-31T23:59:59Z'). Used if the location is temporary.",
       "type": ["null", "string"],
       "format": "date-time"
     }

--- a/schema/json-schema/media_schema.json
+++ b/schema/json-schema/media_schema.json
@@ -14,7 +14,7 @@
       "type": ["null", "string"]
     },
     "sub_type": {
-      "description": "Sub-type for further classification (e.g., Program, Season).",
+      "description": "Sub-type for further classification (e.g., 'Program', 'Season', 'Episode').",
       "type": ["null", "string"]
     },
     "url": {

--- a/schema/json-schema/network_schema.json
+++ b/schema/json-schema/network_schema.json
@@ -6,9 +6,9 @@
   "type": ["null", "object"],
   "properties": {
     "carrier": { "type": ["null", "string"], "description": "The network carrier (e.g. \"Verizon\")." },
-    "cellular": { "type": ["null", "boolean"], "description": "Whether the network is cellular." },
-    "bluetooth": { "type": ["null", "boolean"], "description": "Whether bluetooth is enabled." },
-    "wifi": { "type": ["null", "boolean"], "description": "Whether wifi is enabled." }
+    "cellular": { "type": ["null", "boolean"], "description": "Whether the network is cellular (e.g., true)." },
+    "bluetooth": { "type": ["null", "boolean"], "description": "Whether bluetooth is enabled (e.g., true)." },
+    "wifi": { "type": ["null", "boolean"], "description": "Whether wifi is enabled (e.g., true)." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/page_schema.json
+++ b/schema/json-schema/page_schema.json
@@ -11,8 +11,8 @@
     "referrer": { "type": ["null", "string"], "description": "The referrer of the page (e.g. \"https://segment.com\")." },
     "referring_domain": { "type": ["null", "string"], "description": "The referring domain of the page (e.g. \"segment.com\")." },
     "search": { "type": ["null", "string"], "description": "The search query of the page (e.g. \"segment\")." },
-    "title": { "type": ["null", "string"], "description": "The title of the page." },
-    "url": { "type": ["null", "string"], "format": "uri", "description": "The URL of the page." }
+    "title": { "type": ["null", "string"], "description": "The title of the page (e.g., 'Analytics.js Quickstart - Segment')." },
+    "url": { "type": ["null", "string"], "format": "uri", "description": "The URL of the page (e.g., 'https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/')." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/product_schema.json
+++ b/schema/json-schema/product_schema.json
@@ -5,82 +5,325 @@
   "description": "Schema for a product within a commerce event.",
   "type": ["null", "object"],
   "properties": {
-    "position": { "type": ["null", "integer"] },
-    "entry_type": { "type": ["null", "string"] },
-    "line_id": { "type": ["null", "string"] },
-    "product_id": { "type": ["null", "string"] },
-    "entity_gid": { "type": ["null", "string"], "format": "uuid" },
-    "sku": { "type": ["null", "string"] },
-    "barcode": { "type": ["null", "string"] },
-    "gtin": { "type": ["null", "string"] },
-    "upc": { "type": ["null", "string"] },
-    "ean": { "type": ["null", "string"] },
-    "isbn": { "type": ["null", "string"] },
-    "serial_number": { "type": ["null", "string"] },
-    "supplier_number": { "type": ["null", "string"] },
-    "tpx_serial_number": { "type": ["null", "string"] },
-    "bundle_id": { "type": ["null", "string"] },
-    "bundle": { "type": ["null", "string"] },
-    "product": { "type": ["null", "string"] },
-    "variant": { "type": ["null", "string"] },
-    "novelty": { "type": ["null", "string"] },
-    "size": { "type": ["null", "string"] },
-    "packaging": { "type": ["null", "string"] },
-    "condition": { "type": ["null", "string"] },
-    "ready_for_use": { "type": ["null", "boolean"] },
-    "core_product": { "type": ["null", "string"] },
-    "origin": { "type": ["null", "string"] },
-    "brand": { "type": ["null", "string"] },
-    "product_line": { "type": ["null", "string"] },
-    "own_product": { "type": ["null", "boolean"] },
-    "product_dist": { "type": ["null", "string"] },
-    "main_category": { "type": ["null", "string"] },
-    "main_category_id": { "type": ["null", "string"] },
-    "category": { "type": ["null", "string"] },
-    "category_id": { "type": ["null", "string"] },
-    "gs1_brick_id": { "type": ["null", "string"] },
-    "gs1_brick": { "type": ["null", "string"] },
-    "gs1_brick_short": { "type": ["null", "string"] },
-    "gs1_brick_variant": { "type": ["null", "string"] },
-    "gs1_conditions": { "type": ["null", "string"] },
-    "gs1_processed": { "type": ["null", "string"] },
-    "gs1_consumable": { "type": ["null", "string"] },
-    "gs1_class": { "type": ["null", "string"] },
-    "gs1_family": { "type": ["null", "string"] },
-    "gs1_segment": { "type": ["null", "string"] },
-    "starts": { "type": ["null", "string"], "format": "date-time" },
-    "ends": { "type": ["null", "string"], "format": "date-time" },
-    "duration": { "type": ["null", "number"], "format": "float" },
-    "seats": { "type": ["null", "string"] },
-    "destination": { "type": ["null", "string"] },
-    "lead_time": { "type": ["null", "number"], "format": "float" },
-    "dwell_time_ms": { "type": ["null", "integer"] },
-    "supplier": { "type": ["null", "string"] },
-    "supplier_id": { "type": ["null", "string"] },
-    "manufacturer": { "type": ["null", "string"] },
-    "manufacturer_id": { "type": ["null", "string"] },
-    "promoter": { "type": ["null", "string"] },
-    "promoter_id": { "type": ["null", "string"] },
-    "product_mgr_id": { "type": ["null", "string"] },
-    "product_mgr": { "type": ["null", "string"] },
-    "units": { "type": ["null", "number"], "format": "double" },
-    "unit_size": { "type": ["null", "number"], "format": "double" },
-    "uom": { "type": ["null", "string"] },
-    "unit_price": { "type": ["null", "number"], "format": "double" },
-    "unit_cost": { "type": ["null", "number"], "format": "double" },
-    "bundled_units": { "type": ["null", "integer"] },
-    "price_bracket": { "type": ["null", "string"] },
-    "income_category": { "type": ["null", "string"] },
-    "tax_percentage": { "type": ["null", "number"], "format": "float" },
-    "discount_percentage": { "type": ["null", "number"], "format": "float" },
-    "kickback_percentage": { "type": ["null", "number"], "format": "float" },
-    "commission": { "type": ["null", "number"], "format": "float" },
-    "coupon": { "type": ["null", "string"] },
-    "scale_item": { "type": ["null", "boolean"] },
-    "price_changed": { "type": ["null", "boolean"] },
-    "line_discounted": { "type": ["null", "boolean"] },
-    "url": { "type": ["null", "string"], "format": "uri" },
-    "img_url": { "type": ["null", "string"], "format": "uri" }
+    "position": {
+      "description": "Position of the product in a list of products (e.g., in a cart or order).",
+      "type": ["null", "integer"]
+    },
+    "entry_type": {
+      "description": "Type of line item, if applicable (e.g., 'Product', 'Fee', 'Discount', 'Tax', 'Shipping', 'Service', 'Subscription', 'Other').",
+      "type": ["null", "string"]
+    },
+    "line_id": {
+      "description": "Unique ID for the line item.",
+      "type": ["null", "string"]
+    },
+    "product_id": {
+      "description": "Unique ID for the product in the source system (e.g., '507f1f77bcf86cd799439011').",
+      "type": ["null", "string"]
+    },
+    "entity_gid": {
+      "description": "The Graph UUID (GID) of the product entity, if this product is represented as an entity in ContextSuite.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "sku": {
+      "description": "SKU (Stock Keeping Unit) of the product (e.g., '45790-32').",
+      "type": ["null", "string"]
+    },
+    "barcode": {
+      "description": "Barcode of the product (e.g., scanned barcode).",
+      "type": ["null", "string"]
+    },
+    "gtin": {
+      "description": "GTIN (Global Trade Item Number) of the product.",
+      "type": ["null", "string"]
+    },
+    "upc": {
+      "description": "UPC (Universal Product Code) of the product.",
+      "type": ["null", "string"]
+    },
+    "ean": {
+      "description": "EAN (European Article Number) of the product.",
+      "type": ["null", "string"]
+    },
+    "isbn": {
+      "description": "ISBN (International Standard Book Number) of the product.",
+      "type": ["null", "string"]
+    },
+    "serial_number": {
+      "description": "Serial number of the product.",
+      "type": ["null", "string"]
+    },
+    "supplier_number": {
+      "description": "Supplier number for the product.",
+      "type": ["null", "string"]
+    },
+    "tpx_serial_number": {
+      "description": "TPX serial number for the product (specific to some industries).",
+      "type": ["null", "string"]
+    },
+    "bundle_id": {
+      "description": "ID of the bundle this product belongs to, if applicable.",
+      "type": ["null", "string"]
+    },
+    "bundle": {
+      "description": "Name of the bundle this product belongs to (e.g., 'Starter Pack').",
+      "type": ["null", "string"]
+    },
+    "product": {
+      "description": "Name of the product (e.g., 'Monopoly: 3rd Edition').",
+      "type": ["null", "string"]
+    },
+    "variant": {
+      "description": "Variant of the product (e.g., 'Red', 'XL').",
+      "type": ["null", "string"]
+    },
+    "novelty": {
+      "description": "Novelty status or type of the product (e.g., 'New', 'Refurbished', 'Limited Edition').",
+      "type": ["null", "string"]
+    },
+    "size": {
+      "description": "Size of the product (e.g., 'XL', '100ml').",
+      "type": ["null", "string"]
+    },
+    "packaging": {
+      "description": "Packaging type of the product (e.g., 'Box', 'Bottle', 'Bag').",
+      "type": ["null", "string"]
+    },
+    "condition": {
+      "description": "Condition of the product (e.g., 'New', 'Used', 'Refurbished', 'Damaged', 'Sample', 'Expired', 'Recalled', 'Returned', 'Other').",
+      "type": ["null", "string"]
+    },
+    "ready_for_use": {
+      "description": "Indicates if the product is ready for use (e.g., true for a pre-assembled item, false for an item requiring setup).",
+      "type": ["null", "boolean"]
+    },
+    "core_product": {
+      "description": "Core product identifier or name, if this product is part of a larger offering (e.g., 'iPhone' for an 'iPhone 13 Pro Max 256GB Sierra Blue').",
+      "type": ["null", "string"]
+    },
+    "origin": {
+      "description": "Origin of the product (e.g., country of manufacture, 'Organic', 'Fair Trade').",
+      "type": ["null", "string"]
+    },
+    "brand": {
+      "description": "Brand name of the product (e.g., 'Apple', 'Google').",
+      "type": ["null", "string"]
+    },
+    "product_line": {
+      "description": "Product line the product belongs to (e.g., 'iPhone', 'Pixel').",
+      "type": ["null", "string"]
+    },
+    "own_product": {
+      "description": "Indicates if this is an own-brand product (e.g., true if the seller is also the brand).",
+      "type": ["null", "boolean"]
+    },
+    "product_dist": {
+      "description": "Distribution channel or type for the product (e.g., 'Retail', 'Online', 'Wholesale', 'Direct Sale', 'Reseller', 'Marketplace', 'Other').",
+      "type": ["null", "string"]
+    },
+    "main_category": {
+      "description": "Main category of the product (e.g., 'Games').",
+      "type": ["null", "string"]
+    },
+    "main_category_id": {
+      "description": "ID of the main category.",
+      "type": ["null", "string"]
+    },
+    "category": {
+      "description": "Sub-category of the product (e.g., 'Board Games').",
+      "type": ["null", "string"]
+    },
+    "category_id": {
+      "description": "ID of the sub-category.",
+      "type": ["null", "string"]
+    },
+    "gs1_brick_id": {
+      "description": "GS1 Global Product Classification (GPC) Brick ID (e.g., '10000000').",
+      "type": ["null", "string"]
+    },
+    "gs1_brick": {
+      "description": "GS1 GPC Brick description (e.g., 'Toys/Games (Non-Powered)').",
+      "type": ["null", "string"]
+    },
+    "gs1_brick_short": {
+      "description": "Short description for the GS1 GPC Brick.",
+      "type": ["null", "string"]
+    },
+    "gs1_brick_variant": {
+      "description": "Variant of the GS1 GPC Brick.",
+      "type": ["null", "string"]
+    },
+    "gs1_conditions": {
+      "description": "GS1 GPC Brick Conditions (e.g., 'New', 'Used').",
+      "type": ["null", "string"]
+    },
+    "gs1_processed": {
+      "description": "GS1 GPC Brick Processed Status (e.g., 'Raw', 'Processed').",
+      "type": ["null", "string"]
+    },
+    "gs1_consumable": {
+      "description": "GS1 Brick Consumable Status (e.g., 'Yes', 'No').",
+      "type": ["null", "string"]
+    },
+    "gs1_class": {
+      "description": "GS1 GPC Class description (e.g., 'Traditional Games').",
+      "type": ["null", "string"]
+    },
+    "gs1_family": {
+      "description": "GS1 GPC Family description (e.g., 'Board Games/Puzzles').",
+      "type": ["null", "string"]
+    },
+    "gs1_segment": {
+      "description": "GS1 GPC Segment description (e.g., 'Toys/Games').",
+      "type": ["null", "string"]
+    },
+    "starts": {
+      "description": "Start date/time for a service or subscription product.",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "ends": {
+      "description": "End date/time for a service or subscription product.",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "duration": {
+      "description": "Duration of the service or subscription in a standardized unit (e.g., days, months).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "seats": {
+      "description": "Number of seats or users for a service or subscription product.",
+      "type": ["null", "string"]
+    },
+    "destination": {
+      "description": "Destination for a travel product (e.g., 'Paris', 'London').",
+      "type": ["null", "string"]
+    },
+    "lead_time": {
+      "description": "Lead time for the product in days (e.g., for shipping or manufacturing).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "dwell_time_ms": {
+      "description": "Dwell time in milliseconds, often used for product views or interactions.",
+      "type": ["null", "integer"]
+    },
+    "supplier": {
+      "description": "Name of the supplier.",
+      "type": ["null", "string"]
+    },
+    "supplier_id": {
+      "description": "ID of the supplier.",
+      "type": ["null", "string"]
+    },
+    "manufacturer": {
+      "description": "Name of the manufacturer.",
+      "type": ["null", "string"]
+    },
+    "manufacturer_id": {
+      "description": "ID of the manufacturer.",
+      "type": ["null", "string"]
+    },
+    "promoter": {
+      "description": "Name of the promoter or affiliate.",
+      "type": ["null", "string"]
+    },
+    "promoter_id": {
+      "description": "ID of the promoter or affiliate.",
+      "type": ["null", "string"]
+    },
+    "product_mgr_id": {
+      "description": "ID of the product manager.",
+      "type": ["null", "string"]
+    },
+    "product_mgr": {
+      "description": "Name of the product manager.",
+      "type": ["null", "string"]
+    },
+    "units": {
+      "description": "Number of units of the product (e.g., quantity).",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "unit_size": {
+      "description": "Size of a single unit (e.g., 250 for 250ml).",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "uom": {
+      "description": "Unit of measure for the product (e.g., 'ml', 'kg', 'piece').",
+      "type": ["null", "string"]
+    },
+    "unit_price": {
+      "description": "Price per unit of the product.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "unit_cost": {
+      "description": "Cost per unit of the product.",
+      "type": ["null", "number"],
+      "format": "double"
+    },
+    "bundled_units": {
+      "description": "Number of individual items in a bundle.",
+      "type": ["null", "integer"]
+    },
+    "price_bracket": {
+      "description": "Price bracket or tier for the product (e.g., 'Budget', 'Premium').",
+      "type": ["null", "string"]
+    },
+    "income_category": {
+      "description": "Income category or revenue type for the product (e.g., 'New Sales', 'Renewal', 'Upgrade').",
+      "type": ["null", "string"]
+    },
+    "tax_percentage": {
+      "description": "Tax percentage applied to the product (e.g., 0.2 for 20% tax).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "discount_percentage": {
+      "description": "Discount percentage applied to the product (e.g., 0.1 for 10% discount).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "kickback_percentage": {
+      "description": "Kickback percentage associated with the product sale (e.g., for affiliates or partners).",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "commission": {
+      "description": "Commission amount or percentage for the product sale.",
+      "type": ["null", "number"],
+      "format": "float"
+    },
+    "coupon": {
+      "description": "Coupon code used for the product (e.g., 'PRODUCT10').",
+      "type": ["null", "string"]
+    },
+    "scale_item": {
+      "description": "Indicates if the item is sold by weight or measure (e.g., true for items sold by kg at a deli counter).",
+      "type": ["null", "boolean"]
+    },
+    "price_changed": {
+      "description": "Indicates if the price was manually changed or overridden (e.g., true if a cashier entered a different price).",
+      "type": ["null", "boolean"]
+    },
+    "line_discounted": {
+      "description": "Indicates if the line item was discounted (e.g., true if a discount was applied specifically to this product).",
+      "type": ["null", "boolean"]
+    },
+    "url": {
+      "description": "URL of the product page (e.g., 'https://www.example.com/product/monopoly').",
+      "type": ["null", "string"],
+      "format": "uri"
+    },
+    "img_url": {
+      "description": "URL of an image of the product (e.g., 'https://www.example.com/images/monopoly.jpg').",
+      "type": ["null", "string"],
+      "format": "uri"
+    }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/referrer_schema.json
+++ b/schema/json-schema/referrer_schema.json
@@ -5,8 +5,8 @@
   "description": "Schema for referrer information.",
   "type": ["null", "object"],
   "properties": {
-    "id": { "type": ["null", "string"], "description": "The referrer ID." },
-    "type": { "type": ["null", "string"], "description": "The referrer type." }
+    "id": { "type": ["null", "string"], "description": "The referrer ID (e.g., '3c8da4a4-4f4b-11e5-9e98-2f3c942e34c8')." },
+    "type": { "type": ["null", "string"], "description": "The referrer type (e.g., 'dataxu')." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/screen_schema.json
+++ b/schema/json-schema/screen_schema.json
@@ -5,11 +5,11 @@
   "description": "Schema for screen information.",
   "type": ["null", "object"],
   "properties": {
-    "density": { "type": ["null", "integer"], "description": "The density of the screen." },
-    "height": { "type": ["null", "integer"], "description": "The height of the screen." },
-    "width": { "type": ["null", "integer"], "description": "The width of the screen." },
-    "inner_height": { "type": ["null", "integer"], "description": "The inner height of the screen viewport." },
-    "inner_width": { "type": ["null", "integer"], "description": "The inner width of the screen viewport." }
+    "density": { "type": ["null", "integer"], "description": "The density of the screen (e.g., 2)." },
+    "height": { "type": ["null", "integer"], "description": "The height of the screen in pixels (e.g., 568)." },
+    "width": { "type": ["null", "integer"], "description": "The width of the screen in pixels (e.g., 320)." },
+    "inner_height": { "type": ["null", "integer"], "description": "The inner height of the screen viewport in pixels (e.g., 568)." },
+    "inner_width": { "type": ["null", "integer"], "description": "The inner width of the screen viewport in pixels (e.g., 320)." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/semantic_event.json
+++ b/schema/json-schema/semantic_event.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "entity_gid": {
-      "description": "The entity that the event is associated with (Context Suite Specific)",
+      "description": "The entity that the event is associated with (Context Suite Specific) (Account or any sub-entity).",
       "type": "string",
       "format": "uuid"
     },
@@ -23,24 +23,64 @@
       "description": "The event name (e.g. \"Product Added\") always capitalized and always ended with a verb in passed tense",
       "type": ["null", "string"]
     },
-    "anonymous_id": { "type": ["null", "string"] },
-    "anonymous_gid": { "type": ["null", "string"], "format": "uuid" },
-    "user_id": { "type": ["null", "string"] },
-    "user_gid": { "type": ["null", "string"], "format": "uuid" },
-    "account_id": { "type": ["null", "string"] },
-    "previous_id": { "type": ["null", "string"] },
-    "session_id": { "type": ["null", "string"] },
-    "session_gid": { "type": ["null", "string"], "format": "uuid" },
-    "context_ip": { "type": ["null", "string"], "format": "ipv4" },
-    "importance": { "type": ["null", "integer"], "minimum": 1, "maximum": 5 },
-    "customer_facing": { "type": "integer", "default": 0 },
+    "anonymous_id": {
+      "description": "The anonymous ID of the user before they are identified.",
+      "type": ["null", "string"]
+    },
+    "anonymous_gid": {
+      "description": "The anonymous GID (UUID) of the user before they are identified.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "user_id": {
+      "description": "The user ID of the user.",
+      "type": ["null", "string"]
+    },
+    "user_gid": {
+      "description": "The user GID (UUID) of the user.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "account_id": {
+      "description": "The account ID of the user (Often the same as the entity_gid).",
+      "type": ["null", "string"]
+    },
+    "previous_id": {
+      "description": "The user ID of the user before the event (e.g. 'anonymousId' before 'identify').",
+      "type": ["null", "string"]
+    },
+    "session_id": {
+      "description": "The session ID of the user in the client that generated the event.",
+      "type": ["null", "string"]
+    },
+    "session_gid": {
+      "description": "The session GID (UUID) of the user session that generated the event.",
+      "type": ["null", "string"],
+      "format": "uuid"
+    },
+    "context_ip": {
+      "description": "The IP address of the user in IPv4 format.",
+      "type": ["null", "string"],
+      "format": "ipv4"
+    },
+    "importance": {
+      "description": "The importance of the event (e.g., 1-5).",
+      "type": ["null", "integer"],
+      "minimum": 1,
+      "maximum": 5
+    },
+    "customer_facing": {
+      "description": "Indicates if the event is customer-facing (e.g., for UI display). Typically 0 for false, 1 for true. Default is 0.",
+      "type": "integer",
+      "default": 0
+    },
     "content": {
-      "description": "A dictionary of additional content associated with the event",
+      "description": "A dictionary of additional content associated with the event. Keys can be 'Body', 'Subject', 'Title', 'Description', 'Summary', 'Initial Response', 'Other', etc.",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     },
     "involves": {
-      "description": "Entities involved in the event",
+      "description": "Entities involved in the event. Involvement can be implicit (via other properties) or explicit using this structure. Defined in 'involved_schema.json'.",
       "type": ["null", "array"],
       "items": { "$ref": "involved_schema.json" }
     },
@@ -70,7 +110,7 @@
       "items": { "$ref": "contextual_awareness_schema.json" }
     },
     "properties": {
-      "description": "Additional properties for the event",
+      "description": "A dictionary of additional properties for the event. Properties may be moved into dedicated columns if possible; otherwise, they are stored here.",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     },
@@ -103,7 +143,7 @@
     "context": { "$ref": "context_schema.json" },
     "commerce": { "$ref": "commerce_schema.json" },
     "analysis": {
-      "description": "Cost analysis of the event (internal use)",
+      "description": "Cost analysis of the event. This is strictly for internal use and should not be used for any other purpose. Defined in 'analysis_schema.json'.",
       "type": ["null", "array"],
       "items": { "$ref": "analysis_schema.json" }
     },
@@ -118,24 +158,62 @@
       "items": { "$ref": "access_schema.json" }
     },
     "source": { "$ref": "source_info_schema.json" },
-    "local_time": { "type": ["null", "string"], "format": "date-time" },
-    "original_timestamp": { "type": ["null", "string"], "format": "date-time" },
-    "received_at": { "type": ["null", "string"], "format": "date-time" },
-    "sent_at": { "type": ["null", "string"], "format": "date-time" },
-    "message_id": { "type": "string" },
-    "event_gid": { "type": "string", "format": "uuid" },
-    "root_event_gid": { "type": "string", "format": "uuid" },
+    "local_time": {
+      "description": "The original timestamp of the event in the local timezone of the sender.",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "original_timestamp": {
+      "description": "The original timestamp of when the event occurred, as reported by the source.",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "received_at": {
+      "description": "The timestamp when the event was received by the collection system (e.g., Segment).",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "sent_at": {
+      "description": "The timestamp when the event was sent by the client library.",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "message_id": {
+      "description": "A unique ID for each message, typically assigned by the client library.",
+      "type": "string"
+    },
+    "event_gid": {
+      "description": "A unique GID (UUID) for each message, calculated on the server side from the message_id or other factors if missing.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "root_event_gid": {
+      "description": "The root event GID (UUID) of the event. If this is a derived (higher order) event, this field will be populated with the GID of the original root event.",
+      "type": "string",
+      "format": "uuid"
+    },
     "analyse": {
+      "description": "Custom analysis flags that override the default analysis behavior for this event.",
       "type": ["null", "object"],
       "additionalProperties": { "type": "boolean" }
     },
     "integrations": {
+      "description": "Custom integration flags that override the default integration behavior for this event.",
       "type": ["null", "object"],
       "additionalProperties": { "type": "boolean" }
     },
-    "write_key": { "type": "string" },
-    "ttl_days": { "type": ["null", "number"] },
-    "partition": { "type": "string" }
+    "write_key": {
+      "description": "The write key used to send the event (e.g., a salted hash of the actual write key). Internal field, not user-settable via API.",
+      "type": "string"
+    },
+    "ttl_days": {
+      "description": "The number of days the event will be stored in the database. Defaults to forever if null.",
+      "type": ["null", "number"]
+    },
+    "partition": {
+      "description": "The version of the event message. Internal field used for partitioning, not user-settable via API.",
+      "type": "string"
+    }
   },
   "required": [
     "entity_gid",

--- a/schema/json-schema/source_info_schema.json
+++ b/schema/json-schema/source_info_schema.json
@@ -5,10 +5,10 @@
   "description": "Schema for information about the source system or input of an event.",
   "type": ["null", "object"],
   "properties": {
-    "type": { "type": ["null", "string"], "description": "Type of the source (e.g., 'CRM', 'ERP', 'API')." },
+    "type": { "type": ["null", "string"], "description": "Type of the source (e.g., 'CRM', 'ERP', 'eCommerce', 'Social', 'Email', 'SMS', 'Web', 'Mobile', 'API', 'Other')." },
     "label": { "type": ["null", "string"], "description": "Label for the source (e.g., 'Salesforce Production')." },
-    "source_gid": { "type": ["null", "string"], "format": "uuid", "description": "GID of the source system entity, if applicable." },
-    "access_gid": { "type": ["null", "string"], "format": "uuid", "description": "GID related to the access credentials or method used for this source." }
+    "source_gid": { "type": ["null", "string"], "format": "uuid", "description": "The Graph UUID of the source system entity for the event, if applicable." },
+    "access_gid": { "type": ["null", "string"], "format": "uuid", "description": "The Graph UUID related to the authentication details or access method used for this source." }
   },
   "additionalProperties": false
 }

--- a/schema/json-schema/traits_schema.json
+++ b/schema/json-schema/traits_schema.json
@@ -21,7 +21,7 @@
     "created_at": { "type": ["null", "string"], "format": "date-time", "description": "Timestamp of user creation." },
     "company": { "type": ["null", "string"], "description": "Company the user is associated with." },
     "title": { "type": ["null", "string"], "description": "User's job title." },
-    "gender": { "type": ["null", "string"], "description": "Gender of the user." },
+    "gender": { "type": ["null", "string"], "description": "Gender of the user. Expected values can include 'Male', 'Female', 'Transgender', 'Non-Binary', 'Gender Queer', 'Gender Fluid', 'Gender Neutral', 'Intersex', 'Gender Non-Conforming', 'Gender-Expansive', 'Agender', 'Gendervoid', 'Bigender', 'Omnigender', 'Pangender', 'Two-spirit', 'Trans', or 'No Response', often mapped from an internal Enum." },
     "pronouns": { "type": ["null", "string"], "description": "User's preferred pronouns." },
     "salutation": { "type": ["null", "string"], "description": "Salutation for the user (e.g., Mr., Ms.)." },
     "description": { "type": ["null", "string"], "description": "General description of the user." },

--- a/schema/json-schema/uom.json
+++ b/schema/json-schema/uom.json
@@ -22,15 +22,15 @@
       "type": "string"
     },
     "description": {
-      "description": "Description of the UOM.",
+      "description": "A description of the unit of measure (e.g., 'A kilogram is a unit of mass in the metric system.').",
       "type": ["null", "string"]
     },
     "conversion": {
-      "description": "Conversion factor to a base unit.",
+      "description": "A conversion factor to a base unit (e.g., '1 kg = 1000 g', '1 m = 100 cm').",
       "type": ["null", "string"]
     },
     "core_unit": {
-      "description": "Core unit this UOM is based on (e.g., 'kg' for mass).",
+      "description": "The core unit of measure that this unit is based on (e.g., 'kg' for mass, 'm' for length).",
       "type": ["null", "string"]
     },
     "level": {
@@ -38,12 +38,12 @@
       "type": ["null", "string"]
     },
     "sectors": {
-      "description": "Sectors where this UOM is applicable.",
+      "description": "The sectors that this unit of measure is applicable to (e.g., 'agriculture', 'energy', 'transportation').",
       "type": ["null", "array"],
       "items": { "type": "string" }
     },
     "quantities": {
-      "description": "Quantities this UOM can measure.",
+      "description": "The quantities that this unit of measure can measure (e.g., 'mass', 'length', 'time').",
       "type": ["null", "array"],
       "items": { "type": "string" }
     },
@@ -52,7 +52,7 @@
       "type": ["null", "string"]
     },
     "properties": {
-      "description": "Additional properties for the UOM.",
+      "description": "Additional properties for the unit of measure (e.g., 'precision', 'accuracy').",
       "type": ["null", "object"],
       "additionalProperties": { "type": "string" }
     }

--- a/schema/json-schema/user_agent_schema.json
+++ b/schema/json-schema/user_agent_schema.json
@@ -5,8 +5,8 @@
   "description": "Schema for user agent information.",
   "type": ["null", "object"],
   "properties": {
-    "signature": { "type": ["null", "string"], "description": "The full User-Agent string." },
-    "mobile": { "type": ["null", "boolean"], "description": "Whether the user agent is identified as mobile." },
+    "signature": { "type": ["null", "string"], "description": "The full User-Agent string (e.g., 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36')." },
+    "mobile": { "type": ["null", "boolean"], "description": "Whether the user agent is identified as mobile (e.g., true)." },
     "platform": { "type": ["null", "string"], "description": "The platform of the user agent (e.g., 'Apple Mac', 'Windows')." },
     "data": {
       "type": ["null", "array"],


### PR DESCRIPTION
This commit updates numerous JSON schema files in `schema/json-schema/` to include more detailed descriptions for their properties. The descriptions were sourced from comments in the corresponding ClickHouse SQL definition files (`schema/sql/*.sql`) as per your request.

Key actions I took:
- I identified all JSON schema files and their likely SQL source files.
- I systematically reviewed primary schemas:
    - `data_point.json` (updated from `data_points.sql`)
    - `entity.json` (updated from `entities.sql`)
    - `semantic_event.json` (direct properties updated from `semantic_events.sql`)
    - `timeseries.json` (reviewed against `series.sql`, no changes needed)
    - `uom.json` (updated from `uom.sql`)
- I reviewed and updated numerous other nested/referenced schemas based on comments in `semantic_events.sql` and `entities.sql`. This included:
    - `device_schema.json`
    - `network_schema.json`
    - `traits_schema.json`
    - `page_schema.json`
    - `referrer_schema.json`
    - `screen_schema.json`
    - `context_schema.json`
    - `source_info_schema.json`
    - `access_schema.json`
    - `base_event_info_schema.json`
    - `classification_schema.json`
    - `location_schema.json`
    - `entity_linking_schema.json`
    - `involved_schema.json`
    - `contextual_awareness_schema.json`
    - `commerce_schema.json` (excluding products array itself)
    - `product_schema.json` (extensive updates from `commerce.products` nested comments)
    - `media_schema.json`
    - `content_schema.json`
    - `embeddings_schema.json`
- Schemas like `campaign_schema.json`, `app_schema.json`, `os_schema.json`, `library_schema.json`, `user_agent_data_schema.json`, `analysis_schema.json`, `id_schema.json`, and `defined_metric_schema.json` were reviewed but required no changes as their descriptions were already adequate or the SQL source lacked specific comments for their fields.

My goal was to ensure that the `description` field for each property in the JSON schemas accurately reflects the information available in the SQL comments, making the schemas more self-documenting and easier for you to understand.