### PR TITLE
Fix import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Project specific
+*.log
+*.db
+*.sqlite
+
+# Jupyter Notebooks
+.ipynb_checkpoints
+
+# Local development configuration
+local_settings.py

--- a/python/cxs/core/utils/event_utils.py
+++ b/python/cxs/core/utils/event_utils.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+
+def calculate_event_id(event_data=None, event_type=None, timestamp=None, entity_id=None):
+    """
+    Calculate a deterministic event ID based on the provided parameters.
+    
+    Args:
+        event_data (dict, optional): Event data.
+        event_type (str, optional): The type of event.
+        timestamp (datetime, optional): Event timestamp.
+        entity_id (str, optional): Entity ID associated with the event.
+        
+    Returns:
+        str: A unique event ID as a UUID string.
+    """
+    id_components = []
+    
+    if event_data:
+        id_components.append(str(event_data))
+    
+    if event_type:
+        id_components.append(str(event_type))
+    
+    if timestamp:
+        id_components.append(timestamp.isoformat())
+    else:
+        id_components.append(datetime.now().isoformat())
+    
+    if entity_id:
+        id_components.append(str(entity_id))
+    
+    combined_string = ":".join(id_components)
+    
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, combined_string))

--- a/python/cxs/schema/pydantic/entity.py
+++ b/python/cxs/schema/pydantic/entity.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Annotated, Dict, Optional
 from pydantic import BaseModel, Field, model_validator
 
-from schema.pydantic import CXSBase, OmitIfNone
+from cxs.schema.pydantic import CXSBase, OmitIfNone
 from cxs.core.utils.gid import normalize_gid_url, create_gid
 
 

--- a/python/cxs/schema/pydantic/semantic_event.py
+++ b/python/cxs/schema/pydantic/semantic_event.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import logging
 from pydantic import Field, model_validator, BaseModel
-from schema.pydantic import CXSBase, OmitIfNone
+from cxs.schema.pydantic import CXSBase, OmitIfNone
 from cxs.core.utils.event_utils import calculate_event_id
 
 logger = logging.getLogger(__name__)

--- a/python/cxs/schema/pydantic/timeseries.py
+++ b/python/cxs/schema/pydantic/timeseries.py
@@ -6,11 +6,11 @@ import math
 from datetime import datetime
 from enum import Enum
 from pydantic import BaseModel, Field, model_validator
-from schema.pydantic.entity import Entity
-from schema.pydantic.uom import UOM
+from cxs.schema.pydantic.entity import Entity
+from cxs.schema.pydantic.uom import UOM
 from cxs.core.utils.gid import create_gid
 
-from schema.pydantic import OmitIfNone
+from cxs.schema.pydantic import OmitIfNone
 
 
 class ValueType(str, Enum):

--- a/python/cxs/schema/pydantic/uom.py
+++ b/python/cxs/schema/pydantic/uom.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Annotated, Optional, List, Dict
 
 class UOM(str, Enum):
     code_2A = {'slug': 'radiancode_percode_second', 'symbol': 'rad/s', 'conversion': 'rad/s'}
@@ -1367,7 +1368,7 @@ class UOM(str, Enum):
 
 from typing import List, Dict, Optional # Added for UOMModel
 from pydantic import Field # Added for UOMModel
-from schema.pydantic import CXSBase # Added for UOMModel
+from cxs.schema.pydantic import CXSBase, OmitIfNone # Added for UOMModel
 
 
 class UOMModel(CXSBase):

--- a/python/cxs/schema/validate_pydantic_models.py
+++ b/python/cxs/schema/validate_pydantic_models.py
@@ -91,7 +91,7 @@ def validate_pydantic_models(models_dir, pydantic_module):
             module_name_part = filename[:-3]  # Remove .py extension
             # Assuming models_dir is "pydantic/" relative to script location (cxs-schema)
             # Then the package is 'pydantic' and module is 'module_name_part'
-            module_to_import = f"pydantic.{module_name_part}"
+            module_to_import = f"cxs.schema.pydantic.{module_name_part}"
 
             filepath = os.path.join(models_dir, filename)
             print(f"Validating '{filepath}' (attempting import as '{module_to_import}')...")

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="cxs",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[
+        "requests==2.32.3",
+        "pydantic==2.11.5",
+        "aiohttp==3.12.11",
+        "aioresponses==0.7.8",
+    ],
+    description="Context Suite Utilities for Data Engineering",
+    author="SmartdataHQ",
+)


### PR DESCRIPTION
# Fix Import Paths and Project Structure

## Overview
This PR resolves import path issues in the Pydantic schema models and establishes proper Python packaging structure for the CXS Utils project. It ensures that the schema validation works correctly and that the Python client can properly use the models.

## Changes
- **Fixed import paths**: Converted relative imports to absolute imports in all schema files
- **Added event_utils.py**: Implemented missing utility function `calculate_event_id` required by semantic_event.py
- **Added Python setup.py**: Created proper package installation support
- **Added .gitignore**: Standard Python project .gitignore file

## Detailed Changes
### Import Path Fixes
- Changed imports in schema files from `from schema.pydantic` to `from cxs.schema.pydantic`
- Updated validation script to properly reference models with absolute imports

### New Utility Implementation
- Created `event_utils.py` with `calculate_event_id()` function that generates deterministic UUIDs for events

### Project Structure
- Added setup.py to enable installing the package in development mode
- Added standard Python .gitignore file to exclude common build artifacts

## Testing Done
- Successfully ran the validation script `python -m cxs.schema.validate_pydantic_models`
- Confirmed all schema files are importable
- Verified Pydantic models can be instantiated without import errors

## How to Test
1. Clone this PR
2. Install the package in development mode: 
``` python
cd python pip install -e .
```
3. Run the validation script:
```python
python -m cxs.schema.validate_pydantic_models
```

## Related Issues
- Fixes import path issues in Pydantic schema models
- Resolves missing utility function `calculate_event_id`
