### PR TITLE
Update Documentation to Reflect Avro as the Ground Truth

### DIFF
--- a/cxs-schema/json-schema/README.md
+++ b/cxs-schema/json-schema/README.md
@@ -5,8 +5,8 @@ This directory contains JSON Schemas that define the structure and constraints f
 ## Overview
 
 The schemas are designed based on a combination of:
--   **ClickHouse SQL table definitions**: Considered the primary source of truth for data structure and nullability.
--   **Avro schemas (`.avsc` files)**: Used for event serialization and data interchange.
+-   **Avro schemas (`.avsc` files)**: Considered the primary source of truth for data structure and field definitions.
+-   **ClickHouse SQL table definitions**: Used for database storage and querying.
 -   **Pydantic models**: Used within the Python applications for data validation and manipulation.
 
 All schemas adhere to the **JSON Schema Draft 2020-12** specification.

--- a/cxs-schema/json-schema/entity.json
+++ b/cxs-schema/json-schema/entity.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://contextsuite.com/schemas/entity.json",
   "title": "ContextSuite Entity",
-  "description": "Schema for a ContextSuite Entity, based on SQL, Avro, and Pydantic models. SQL is the primary source of truth.",
+  "description": "Schema for a ContextSuite Entity, based on SQL, Avro, and Pydantic models. Avro is the primary source of truth.",
   "type": "object",
   "properties": {
     "gid": {

--- a/cxs-schema/json-schema/semantic_event.json
+++ b/cxs-schema/json-schema/semantic_event.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://contextsuite.com/schemas/semantic_event.json",
   "title": "ContextSuite Semantic Event",
-  "description": "Schema for a ContextSuite Semantic Event. SQL is the primary source of truth.",
+  "description": "Schema for a ContextSuite Semantic Event. Avro is the primary source of truth.",
   "type": "object",
   "properties": {
     "entity_gid": {

--- a/docs/pages/docs/semantic-events/validation.md
+++ b/docs/pages/docs/semantic-events/validation.md
@@ -1,11 +1,11 @@
 ---
 title: Event Validation
-description: Validate semantic events against the SQL schema and event modeling rules
+description: Validate semantic events against the Avro schema and event modeling rules
 ---
 
 # Event Validation
 
-The Context Suite includes a robust event validation system that ensures events conform to both the SQL schema definition and event modeling best practices. This validator is dynamically driven by the SQL schema, ensuring that validation rules evolve automatically as the schema is updated.
+The Context Suite includes a robust event validation system that ensures events conform to both the Avro schema definition and event modeling best practices. This validator is dynamically driven by the Avro schema, ensuring that validation rules evolve automatically as the schema is updated.
 
 ## Features
 
@@ -17,23 +17,23 @@ The validator provides comprehensive validation of event JSON objects:
    - Property order recommendations
    - Entity references in `involves` array
    - Nested structure validation
-4. **Unknown Field Detection**: Identifies fields not defined in the SQL schema, including in nested structures
+4. **Unknown Field Detection**: Identifies fields not defined in the Avro schema, including in nested structures
 
 ## How It Works
 
 The validator processes event validation in three steps:
 
-1. **SQL Schema Parsing**: Extracts field definitions, types, and requirements directly from the `semantic_events.sql` file
+1. **Avro Schema Parsing**: Extracts field definitions, types, and requirements directly from the Avro schema files (`.avsc`)
 2. **Event Analysis**: Processes the event structure against schema requirements
 3. **Validation Results**: Provides clear error/warning messages with specific details
 
-Unlike previous validation approaches, this validator is dynamically driven by the SQL schema file, ensuring that validation rules automatically evolve as the schema is updated without requiring code changes.
+Unlike previous validation approaches, this validator is dynamically driven by the Avro schema files, ensuring that validation rules automatically evolve as the schema is updated without requiring code changes.
 
 ## File Structure
 
 The validator consists of three primary components:
 
-- **sql_schema_parser.py**: Parses the SQL schema to extract field definitions and requirements
+- **avro_schema_parser.py**: Parses the Avro schemas to extract field definitions and requirements
 - **event_validator.py**: Core validation logic that checks events against schema rules
 - **run_validator.py**: CLI tool to validate JSON event files
 
@@ -159,7 +159,7 @@ The validator handles several edge cases:
 
 ### Valid Event Example
 
-Below is a complete, validated example of a product_updated event that passes all validation checks against the SQL schema:
+Below is a complete, validated example of a product_updated event that passes all validation checks against the Avro schema:
 
 ```json
 {


### PR DESCRIPTION
# Update Documentation to Reflect Avro as the Ground Truth

## Summary
This PR updates the documentation to clearly establish Avro schemas (`.avsc` files) as the ground truth for data structure and field definitions, replacing previous references to SQL schema as the primary source of truth.

## Changes
- Updated [cxs-schema/json-schema/README.md](cci:7://file:///Users/macbook/Documents/cxs-utils/cxs-schema/json-schema/README.md:0:0-0:0) to position Avro schemas as the primary source of truth
- Updated [docs/pages/docs/semantic-events/validation.md](cci:7://file:///Users/macbook/Documents/cxs-utils/docs/pages/docs/semantic-events/validation.md:0:0-0:0) to reference Avro instead of SQL throughout:
  - Updated page description
  - Changed references from SQL to Avro in the main validation explanation
  - Updated "How It Works" section to reference Avro schema parsing
  - Changed file structure to reference an Avro schema parser
  - Updated example section to mention validation against Avro schema

## Motivation
This change clarifies our schema hierarchy and ensures consistency in our documentation, establishing Avro as the single source of truth for all schema-related operations across the Context Suite ecosystem.

## Testing
- Documentation changes only, no functional code changes
- Verified that all references to SQL as the primary schema have been updated