### PR TITLE
Schema Converter Dependencies Hotfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
         "pydantic>=2.11.5",
         "aiohttp>=3.9.1",
         "aioresponses>=0.7.5",
+        "fastavro>=1.9.1",
+        "deepdiff>=6.3.1",
+        "jsonschema>=4.19.1",
     ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
# Schema Converter Dependencies Hotfix

## Overview

This PR adds the necessary dependencies to `setup.py` for the schema conversion and comparison tools that were recently added to the project. The update ensures that all features documented in the README work correctly when the package is installed.

---

## Changes

### Added the following dependencies to `setup.py`:

* `fastavro>=1.9.1` – For Avro schema handling and conversion
* `deepdiff>=6.3.1` – For schema comparison functionality
* `jsonschema>=4.19.1` – For JSON Schema validation
