### PR TITLE
Add Example Shopify Product Data and Corresponding Semantic Event

### DIFF
--- a/examples/ecommerce/shopify/raw_product_data.json
+++ b/examples/ecommerce/shopify/raw_product_data.json
@@ -1,0 +1,110 @@
+{
+    "admin_graphql_api_id": "gid://shopify/Product/15100602155333",
+    "body_html": "<p>This is test snowboard</p>",
+    "created_at": "2025-06-06T17:32:44-04:00",
+    "handle": "the-test-snowboard",
+    "id": 15100602155333,
+    "product_type": "snowboard",
+    "published_at": "2025-06-06T17:31:23-04:00",
+    "template_suffix": "",
+    "title": "The test snowboard",
+    "updated_at": "2025-06-06T17:32:46-04:00",
+    "vendor": "semantic-events-test",
+    "status": "active",
+    "published_scope": "web",
+    "tags": "Accessory, Snow, Sport, Winter",
+    "variants": [
+      {
+        "admin_graphql_api_id": "gid://shopify/ProductVariant/54880761119045",
+        "barcode": "",
+        "compare_at_price": "20.00",
+        "created_at": "2025-06-06T17:32:45-04:00",
+        "id": 54880761119045,
+        "inventory_policy": "deny",
+        "position": 1,
+        "price": "10.00",
+        "product_id": 15100602155333,
+        "sku": "sku-test-1",
+        "taxable": true,
+        "title": "Default Title",
+        "updated_at": "2025-06-06T17:32:45-04:00",
+        "option1": "Default Title",
+        "option2": null,
+        "option3": null,
+        "image_id": null,
+        "inventory_item_id": 54319739470149,
+        "inventory_quantity": 2,
+        "old_inventory_quantity": 2
+      }
+    ],
+    "options": [
+      {
+        "name": "Title",
+        "id": 17484046074181,
+        "product_id": 15100602155333,
+        "position": 1,
+        "values": ["Default Title"]
+      }
+    ],
+    "images": [
+      {
+        "id": 76266582016325,
+        "product_id": 15100602155333,
+        "position": 1,
+        "created_at": "2025-06-06T17:27:49-04:00",
+        "updated_at": "2025-06-06T17:27:51-04:00",
+        "alt": null,
+        "width": 800,
+        "height": 800,
+        "src": "https://cdn.shopify.com/s/files/1/0954/8323/2581/files/Main_800x800_ce10c297-d884-4431-aab3-aa87490f86d8.webp?v=1749245271",
+        "variant_ids": [],
+        "admin_graphql_api_id": "gid://shopify/ProductImage/76266582016325"
+      }
+    ],
+    "image": {
+      "id": 76266582016325,
+      "product_id": 15100602155333,
+      "position": 1,
+      "created_at": "2025-06-06T17:27:49-04:00",
+      "updated_at": "2025-06-06T17:27:51-04:00",
+      "alt": null,
+      "width": 800,
+      "height": 800,
+      "src": "https://cdn.shopify.com/s/files/1/0954/8323/2581/files/Main_800x800_ce10c297-d884-4431-aab3-aa87490f86d8.webp?v=1749245271",
+      "variant_ids": [],
+      "admin_graphql_api_id": "gid://shopify/ProductImage/76266582016325"
+    },
+    "media": [
+      {
+        "id": 66050134442309,
+        "product_id": 15100602155333,
+        "position": 1,
+        "created_at": "2025-06-06T17:27:49-04:00",
+        "updated_at": "2025-06-06T17:27:51-04:00",
+        "alt": null,
+        "status": "READY",
+        "media_content_type": "IMAGE",
+        "preview_image": {
+          "width": 800,
+          "height": 800,
+          "src": "https://cdn.shopify.com/s/files/1/0954/8323/2581/files/Main_800x800_ce10c297-d884-4431-aab3-aa87490f86d8.webp?v=1749245271",
+          "status": "READY"
+        },
+        "variant_ids": [],
+        "admin_graphql_api_id": "gid://shopify/MediaImage/66050134442309"
+      }
+    ],
+    "variant_gids": [
+      {
+        "admin_graphql_api_id": "gid://shopify/ProductVariant/54880761119045",
+        "updated_at": "2025-06-06T21:32:45.000Z"
+      }
+    ],
+    "has_variants_that_requires_components": false,
+    "category": {
+      "admin_graphql_api_id": "gid://shopify/TaxonomyCategory/sg-4-17-2-17",
+      "name": "Snowboards",
+      "full_name": "Sporting Goods > Outdoor Recreation > Winter Sports & Activities > Skiing & Snowboarding > Snowboards"
+    }
+  }
+  

--- a/examples/ecommerce/shopify/semantic_event.json
+++ b/examples/ecommerce/shopify/semantic_event.json
@@ -1,0 +1,74 @@
+{
+    "type": "track",
+    "event": "Product Updated",
+    "timestamp": "2025-06-06T17:32:46-04:00",
+    "entity_gid": "ede9ed75-dd83-519b-89c2-aa20966962cd",
+    "content": {
+        "Description": "This is test snowboard",
+        "Title": "The test snowboard"
+    },
+    "context": {
+        "ip": "127.0.0.1",
+        "locale": "en-US",
+        "timezone": "America/Los_Angeles"
+    },
+    "involves": [
+        {
+            "entity_type": "Product",
+            "id": "15100602155333",
+            "id_type": "Shopify",
+            "label": "The test snowboard",
+            "role": "Source"
+        },
+        {
+            "entity_type": "Category",
+            "id": "sg-4-17-2-17",
+            "id_type": "ShopifyCategory",
+            "label": "Snowboards",
+            "role": "Classification"
+        }
+    ],
+    "classification": [
+        {
+            "type": "Category",
+            "value": "Sporting Goods"
+        },
+        {
+            "type": "Category",
+            "value": "Outdoor Recreation"
+        },
+        {
+            "type": "Category",
+            "value": "Winter Sports & Activities"
+        },
+        {
+            "type": "Category",
+            "value": "Skiing & Snowboarding"
+        },
+        {
+            "type": "Category",
+            "value": "Snowboards"
+        }
+    ],
+    "commerce": {
+        "products": [
+            {
+                "product_id": "15100602155333",
+                "product": "The test snowboard",
+                "category": "Snowboards",
+                "categories": [
+                    "Sporting Goods",
+                    "Outdoor Recreation", 
+                    "Winter Sports & Activities", 
+                    "Skiing & Snowboarding", 
+                    "Snowboards"
+                ],
+                "url": "gid://shopify/Product/15100602155333"
+            }
+        ]
+    },
+    "source": {
+        "label": "Shopify",
+        "type": "eCommerce"
+    }
+}


### PR DESCRIPTION
# Add Example Shopify Product Data and Corresponding Semantic Event

This PR adds example data files demonstrating the transformation from Shopify's raw product format to Context Suite's semantic event structure.

---

## Added Files

### `raw_product_data.json`

* Example Shopify API response for a snowboard product
* Includes standard product fields such as `id`, `title`, `vendor`, `variants`, and `images`

### `semantic_event.json`

* Corresponding semantic event
* Includes:

  * Proper classification and `@type` information
  * Structured commerce data (e.g., SKU, price, inventory)
  * Entity relationships (e.g., product → brand, product → category)

---

## Purpose

* Demonstrates the mapping from raw Shopify data to a normalized, semantically enriched format
* Serves as a reference for future Shopify integrations
* Supports development and testing of schema transformations and entity linking logic
