### PR TITLE
Fix broken navigation link in event-types.mdoc

### DIFF
--- a/docs/app/docs/semantic-events/event-types.mdoc
+++ b/docs/app/docs/semantic-events/event-types.mdoc
@@ -85,4 +85,4 @@ The `alias` event has a very specific and critical function: to merge two previo
 jitsu.alias('user-97980');
 ```
 
-{% navigation previous="/docs/semantic-events/getting-started" previousTitle="Getting Started" next="/docs/semantic-events/overview" nextTitle="Overview" /%}
+{% navigation previous="/docs/semantic-events/getting-started" previousTitle="Getting Started"/%}


### PR DESCRIPTION
### 📝 PR Description

**Fix broken navigation link in `event-types.mdoc`**

The `next` navigation link at the bottom of the `event-types.mdoc` page was pointing to a non-existent or invalid page (`/docs/semantic-events/overview`). Since all relevant pages are already covered via existing navigation, and there is no corresponding "next" page for this one, the `next` link has been removed to avoid confusion and improve documentation integrity.

### ✅ Changes Made

* Removed the `next` attribute from the `{% navigation %}` tag in `event-types.mdoc`.

### 📌 Context

This change ensures a smoother user experience by preventing broken or misleading navigation within the semantic events documentation.

[change-file-path](https://github.com/BinaryNavigator07/cxs-utils/blob/63f478fc37acd619f2822918e274a53efa7c67da/docs/app/docs/semantic-events/event-types.mdoc)
